### PR TITLE
2021-07-22 GUARD-2021 ChannelAdvisor ChannelAdvisor-Not-All-Products-Synced

### DIFF
--- a/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
@@ -309,13 +309,14 @@ namespace ChannelAdvisorAccess.REST.Services
 			// check if we have extra pages 
 			if ( response.NextLink != null && response.Count != null )
 			{
-				var totalRecords = response.Count.Value;
-				var serviceRecommendedPageSize = this.GetPageSizeFromUrl( response.NextLink );
-				var totalPages = (int)Math.Ceiling( totalRecords * 1.0 / serviceRecommendedPageSize ) + 1; 
+				var totalRecords = response.Count.Value;				
 				
 				// if specific page was not requested
 				if ( pageNumber <= 0 )
 				{
+					var serviceRecommendedPageSize = this.GetPageSizeFromUrl( response.NextLink );
+					var totalPages = ( int )Math.Ceiling( totalRecords * 1.0 / serviceRecommendedPageSize ) + 1;
+
 					var nextPage = 2;
 					var options = new ParallelOptions() {  MaxDegreeOfParallelism = 1 };
 					Parallel.For( nextPage, totalPages, options, () => new List< T >(), ( currentPage, pls, tempResult ) =>
@@ -334,6 +335,8 @@ namespace ChannelAdvisorAccess.REST.Services
 				}
 				else
 				{
+					var totalPages = pageSize.HasValue ? ( int )Math.Ceiling( totalRecords * 1.0 / pageSize.Value ) : 1;
+
 					// if we request non existing page CA always returns first page
 					if ( pageNumber > totalPages )
 					{
@@ -374,7 +377,7 @@ namespace ChannelAdvisorAccess.REST.Services
 			if ( pageSize != null && page > 1 )
 				url += "&$skip=" + ( page - 1 ) * pageSize;
 
-			return GetEntityAsync< ODataResponse< T > >( url, token, mark, operationTimeout );
+			return GetEntityAsync< ODataResponse< T > >( url, token, mark, operationTimeout ); 
 		}
 
 		/// <summary>
@@ -408,8 +411,8 @@ namespace ChannelAdvisorAccess.REST.Services
 
 							ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodParameters: url, methodResult: responseStr, returnStatusCode: httpResponse.StatusCode.ToString(), additionalInfo : this.AdditionalLogInfo(), operationTimeout: operationTimeout ) );
 
-							await this.ThrowIfError( httpResponse, responseStr, cts.Token, mark ).ConfigureAwait( false );
-					
+							await this.ThrowIfError( httpResponse, responseStr, cts.Token, mark ).ConfigureAwait( false );												
+
 							var message = JsonConvert.DeserializeObject< T >( responseStr );
 
 							return message;

--- a/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
@@ -347,7 +347,7 @@ namespace ChannelAdvisorAccess.REST.Services
 				}
 				else
 				{
-					var totalPages = pageSize.HasValue ? ( int )Math.Ceiling( totalRecords * 1.0 / pageSize.Value ) : 1;
+					var totalPages = pageSize.HasValue && pageSize.Value != 0 ? ( int )Math.Ceiling( totalRecords * 1.0 / pageSize.Value ) : 1;
 
 					// if we request non existing page CA always returns first page
 					if ( pageNumber > totalPages )

--- a/src/ChannelAdvisorAccessTests/REST/Inventory/ItemsServiceTests.cs
+++ b/src/ChannelAdvisorAccessTests/REST/Inventory/ItemsServiceTests.cs
@@ -304,10 +304,11 @@ namespace ChannelAdvisorAccessTests.REST.Inventory
 		}
 
 		[Test]
-		public async Task GetFilteredSkusPageByUpdateDateForPeriod()
+		public async Task GetFilteredSkusAllPagesByUpdateDateForPeriod()
 		{
-			var startDate = DateTime.Now.AddDays( -89 );
+			var startDate = DateTime.Now.AddDays( -49 );
 			var endDate = DateTime.Now;
+			const int pageSize = 80;
 
 			var filter = new ItemsFilter
 			{
@@ -324,7 +325,7 @@ namespace ChannelAdvisorAccessTests.REST.Inventory
 			var skus = new List< string >();
 			while ( !skuListSyncComplete )
 			{
-				var result = await this.ItemsService.GetFilteredSkusAsync( filter, skuListStartPage, 100, CancellationToken.None );
+				var result = await this.ItemsService.GetFilteredSkusAsync( filter, skuListStartPage, pageSize, CancellationToken.None );
 				skus.AddRange( result.Response );				
 				skuListSyncComplete = result.AllPagesQueried;
 				skuListStartPage = result.AllPagesQueried ? 1 : result.FinalPageNumber + 1;				

--- a/src/ChannelAdvisorAccessTests/REST/Inventory/ItemsServiceTests.cs
+++ b/src/ChannelAdvisorAccessTests/REST/Inventory/ItemsServiceTests.cs
@@ -303,6 +303,36 @@ namespace ChannelAdvisorAccessTests.REST.Inventory
 			result.Response.Should().NotBeEmpty();
 		}
 
+		[Test]
+		public async Task GetFilteredSkusPageByUpdateDateForPeriod()
+		{
+			var startDate = DateTime.Now.AddDays( -90 );
+			var endDate = DateTime.Now;
+
+			var filter = new ItemsFilter
+			{
+				 Criteria = new InventoryItemCriteria
+				 {
+					DateRangeField = TimeStampFields.LastUpdateDate,
+					DateRangeStartGMT = startDate,
+					DateRangeEndGMT = endDate
+				 }
+			};
+
+			var skuListStartPage = 1;
+			var skuListSyncComplete = false;
+			var skus = new List< string >();
+			while ( !skuListSyncComplete )
+			{
+				var result = await this.ItemsService.GetFilteredSkusAsync( filter, skuListStartPage, 100, CancellationToken.None );
+				skus.AddRange( result.Response );				
+				skuListSyncComplete = result.AllPagesQueried;
+				skuListStartPage = result.AllPagesQueried ? 1 : result.FinalPageNumber + 1;				
+			}
+
+			skus.Should().NotBeNullOrEmpty();
+		}
+
 		[ Test ]
 		public void GetFilteredItemsPageByUpdateDate()
 		{

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.10.2.0" ) ]
+[ assembly : AssemblyVersion( "8.12.1.0" ) ]


### PR DESCRIPTION
**Problem**
Not all products in this client's account are being synced over.

**Solution**
Some products don't really come to SkuVault. In the logz, I do not see SKUs that should fall into the dates range. I also replicated this with a Unit test for client. At the same time, the logs also look strange. If we analyze the logz of pages requests for different periods for the Client, then the total number of SKUs is almost always a multiple of 100.  I reproduced this with Unit tests on the sandbox, and the count value in response is very different (see two samples periods for 55 and 90 days). 

![image](https://user-images.githubusercontent.com/80940351/126594284-a0e5a27a-c90f-41a0-81ef-67e587432ad1.png)

I found a possible reason. It looks like the paged fetch implementation is not working properly. Here, at each iteration, we calculate the number of total pages (totalPages) based on serviceRecommendedPageSize, which changes every iteration, reduces the possible number of requests and is kicked us out of the loop ahead. I think for the 'paging' case we should depend on the actual number of pages based on the total post size and the pageSize value. I've applied the fix and checked it with a unit test (also tested for different page sizes and for non-pagging case when we have pageSize >= totalProducts)

![image](https://user-images.githubusercontent.com/80940351/126594343-dc33f497-7478-46ce-bac5-a99d748dc87d.png)


