### PR TITLE
RLS-2837  2021-12-07 GUARD-2226 ChannelAdvisor-Service-Not-Responding-SOAP-Fix

### DIFF
--- a/src/ChannelAdvisorAccess/REST/Services/Orders/OrdersService.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/Orders/OrdersService.cs
@@ -64,7 +64,7 @@ namespace ChannelAdvisorAccess.REST.Services.Orders
 		/// <param name="startDate"></param>
 		/// <param name="endDate"></param>
 		/// <returns></returns>
-		public IEnumerable< T > GetOrders< T >( DateTime startDate, DateTime endDate, CancellationToken token ) where T : OrderResponseItem
+		public IEnumerable< T > GetOrders< T >( DateTime startDate, DateTime endDate, CancellationToken token, Mark mark = null ) where T : OrderResponseItem
 		{
 			var criteria = new OrderCriteria()
 			{
@@ -72,7 +72,7 @@ namespace ChannelAdvisorAccess.REST.Services.Orders
 				StatusUpdateFilterEndTimeGMT = endDate,
 			};
 
-			return this.GetOrders< T >( criteria, token );
+			return this.GetOrders< T >( criteria, token, mark );
 		}
 
 		/// <summary>
@@ -81,9 +81,9 @@ namespace ChannelAdvisorAccess.REST.Services.Orders
 		/// <typeparam name="T"></typeparam>
 		/// <param name="orderCriteria"></param>
 		/// <returns></returns>
-		public IEnumerable< T > GetOrders< T >( OrderCriteria orderCriteria, CancellationToken token ) where T : OrderResponseItem
+		public IEnumerable< T > GetOrders< T >( OrderCriteria orderCriteria, CancellationToken token, Mark mark = null ) where T : OrderResponseItem
 		{
-			return this.GetOrdersAsync< T >( orderCriteria, token ).GetAwaiter().GetResult();
+			return this.GetOrdersAsync< T >( orderCriteria, token, mark ).GetAwaiter().GetResult();
 		}
 
 		/// <summary>
@@ -93,9 +93,9 @@ namespace ChannelAdvisorAccess.REST.Services.Orders
 		/// <param name="startDate"></param>
 		/// <param name="endDate"></param>
 		/// <returns></returns>
-		public IList< T > GetOrdersList< T >( DateTime startDate, DateTime endDate, CancellationToken token ) where T : OrderResponseItem
+		public IList< T > GetOrdersList< T >( DateTime startDate, DateTime endDate, CancellationToken token, Mark mark = null ) where T : OrderResponseItem
 		{
-			return this.GetOrders< T >( startDate, endDate, token ).ToList();
+			return this.GetOrders< T >( startDate, endDate, token, mark ).ToList();
 		}
 
 		/// <summary>
@@ -105,7 +105,7 @@ namespace ChannelAdvisorAccess.REST.Services.Orders
 		/// <param name="startDate"></param>
 		/// <param name="endDate"></param>
 		/// <returns></returns>
-		public Task< IEnumerable < T > > GetOrdersAsync< T >( DateTime startDate, DateTime endDate, CancellationToken token ) where T : OrderResponseItem
+		public Task< IEnumerable < T > > GetOrdersAsync< T >( DateTime startDate, DateTime endDate, CancellationToken token, Mark mark = null ) where T : OrderResponseItem
 		{
 			OrderCriteria criteria = new OrderCriteria()
 			{
@@ -113,7 +113,7 @@ namespace ChannelAdvisorAccess.REST.Services.Orders
 				StatusUpdateFilterEndTimeGMT = endDate,
 			};
 
-			return this.GetOrdersAsync< T >( criteria, token );
+			return this.GetOrdersAsync< T >( criteria, token, mark );
 		}
 
 		/// <summary>
@@ -217,32 +217,32 @@ namespace ChannelAdvisorAccess.REST.Services.Orders
 			return string.Join( " ", clauses );
 		}
 
-		public void Ping()
+		public void Ping( Mark mark )
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task PingAsync()
+		public Task PingAsync( Mark mark )
 		{
 			throw new NotImplementedException();
 		}
 
-		public int SubmitOrder(OrderSubmit orderSubmit, CancellationToken token )
+		public int SubmitOrder( OrderSubmit orderSubmit, CancellationToken token, Mark mark )
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<int> SubmitOrderAsync(OrderSubmit orderSubmit, CancellationToken token )
+		public Task< int > SubmitOrderAsync( OrderSubmit orderSubmit, CancellationToken token, Mark mark )
 		{
 			throw new NotImplementedException();
 		}
 
-		public IEnumerable<OrderUpdateResponse> UpdateOrderList(OrderUpdateSubmit[] orderUpdates, CancellationToken token)
+		public IEnumerable< OrderUpdateResponse > UpdateOrderList( OrderUpdateSubmit[] orderUpdates, CancellationToken token, Mark mark )
 		{
 			throw new NotImplementedException();
 		}
 
-		public Task<IEnumerable<OrderUpdateResponse>> UpdateOrderListAsync(OrderUpdateSubmit[] orderUpdates, CancellationToken token )
+		public Task< IEnumerable< OrderUpdateResponse > > UpdateOrderListAsync( OrderUpdateSubmit[] orderUpdates, CancellationToken token, Mark mark )
 		{
 			throw new NotImplementedException();
 		}

--- a/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
@@ -751,14 +751,5 @@ namespace ChannelAdvisorAccess.REST.Services
 
 			return pageSize;
 		}
-
-		/// <summary>
-		///	This method is used to update service's last network activity time.
-		///	It's called every time before making API request to server or after handling the response.
-		/// </summary>
-		private void RefreshLastNetworkActivityTime()
-		{
-			this.LastNetworkActivityTime = DateTime.UtcNow;
-		}
 	}
 }

--- a/src/ChannelAdvisorAccess/Services/Admin/AdminService.cs
+++ b/src/ChannelAdvisorAccess/Services/Admin/AdminService.cs
@@ -5,7 +5,6 @@ using ChannelAdvisorAccess.AdminService;
 using ChannelAdvisorAccess.Exceptions;
 using ChannelAdvisorAccess.Misc;
 using ChannelAdvisorAccess.Services.Items;
-using Newtonsoft.Json;
 
 namespace ChannelAdvisorAccess.Services.Admin
 {
@@ -13,53 +12,7 @@ namespace ChannelAdvisorAccess.Services.Admin
 	{
 		private readonly APICredentials _credentials;
 		private readonly AdminServiceSoapClient _client;
-		
-		private string AdditionalLogInfoString
-		{
-			get
-			{
-				if( this.AdditionalLogInfo == null )
-					return string.Empty;
-
-				string res;
-				try
-				{
-					res = this.AdditionalLogInfo();
-				}
-				catch
-				{
-					return string.Empty;
-				}
-
-				return res;
-			}
-		}
-
-		private string CreateMethodCallInfo( string methodParameters = "", Mark mark = null, string errors = "", string methodResult = "", string additionalInfo = "", string notes = "", [ CallerMemberName ] string memberName = "" )
-		{
-			try
-			{
-				mark = mark ?? Mark.Blank();
-				var connectionInfo = this.ToJson();
-				var str = string.Format(
-					"{{Mark:\"{3}\", MethodName:{0}, ConnectionInfo:{1}, MethodParameters:{2} {4}{5}{6}{7}}}",
-					memberName,
-					connectionInfo,
-					string.IsNullOrWhiteSpace( methodParameters ) ? PredefinedValues.EmptyJsonObject : methodParameters,
-					mark,
-					string.IsNullOrWhiteSpace( errors ) ? string.Empty : ", Errors:" + errors,
-					string.IsNullOrWhiteSpace( methodResult ) ? string.Empty : ", Result:" + methodResult,
-					string.IsNullOrWhiteSpace( notes ) ? string.Empty : ",Notes: " + notes,
-					string.IsNullOrWhiteSpace( additionalInfo ) ? string.Empty : ", " + additionalInfo
-					);
-				return str;
-			}
-			catch( Exception )
-			{
-				return PredefinedValues.EmptyJsonObject;
-			}
-		}
-
+				
 		public AdminService( APICredentials credentials )
 		{
 			this._credentials = credentials;
@@ -74,22 +27,24 @@ namespace ChannelAdvisorAccess.Services.Admin
 
 			try
 			{
-				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ) );
+				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 
 				AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = this._client.Ping( this._credentials );
 					this.RefreshLastNetworkActivityTime();
-					this.CheckCaSuccess( result );
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.CheckCaSuccess( result );					
 				} );
 
-				ChannelAdvisorLogger.LogTraceEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ) );
+				ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 			}
 			catch( Exception exception )
 			{
 				this.RefreshLastNetworkActivityTime();
-				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
+				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
 			}
@@ -101,22 +56,24 @@ namespace ChannelAdvisorAccess.Services.Admin
 				mark = Mark.CreateNew();
 			try
 			{
-				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ) );
+				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 
 				await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = await this._client.PingAsync( this._credentials ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
-					this.CheckCaSuccess( result.PingResult );
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.CheckCaSuccess( result.PingResult );					
 				} ).ConfigureAwait( false );
 
-				ChannelAdvisorLogger.LogTraceEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ) );
+				ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 			}
 			catch( Exception exception )
 			{
 				this.RefreshLastNetworkActivityTime();
-				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
+				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
 			}
@@ -129,17 +86,17 @@ namespace ChannelAdvisorAccess.Services.Admin
 				mark = Mark.CreateNew();
 			try
 			{
-				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ) );
+				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 
 				var authorizationResponses = this.GetAuthorizationList( string.Empty, mark );
 
-				ChannelAdvisorLogger.LogTraceEnd( this.CreateMethodCallInfo( mark : mark, methodResult : authorizationResponses.ToJson(), additionalInfo : this.AdditionalLogInfoString ) );
+				ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodResult : authorizationResponses.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
 
 				return authorizationResponses;
 			}
 			catch( Exception exception )
 			{
-				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
+				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
 			}
@@ -151,17 +108,17 @@ namespace ChannelAdvisorAccess.Services.Admin
 				mark = Mark.CreateNew();
 			try
 			{
-				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ) );
+				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 
 				var authorizationResponses = await this.GetAuthorizationListAsync( string.Empty, mark ).ConfigureAwait( false );
 
-				ChannelAdvisorLogger.LogTraceEnd( this.CreateMethodCallInfo( mark : mark, methodResult : authorizationResponses.ToJson(), additionalInfo : this.AdditionalLogInfoString ) );
+				ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodResult : authorizationResponses.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
 
 				return authorizationResponses;
 			}
 			catch( Exception exception )
 			{
-				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
+				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
 			}
@@ -173,25 +130,27 @@ namespace ChannelAdvisorAccess.Services.Admin
 				mark = Mark.CreateNew();
 			try
 			{
-				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString, methodParameters : localId ) );
+				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : localId ) );
 
 				var authorizationResponses = AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = this._client.GetAuthorizationList( this._credentials, localId );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result );
 					return result.ResultData;
 				} );
 
-				ChannelAdvisorLogger.LogTraceEnd( this.CreateMethodCallInfo( mark : mark, methodResult : authorizationResponses.ToJson(), additionalInfo : this.AdditionalLogInfoString, methodParameters : localId ) );
+				ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodResult : authorizationResponses.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : localId ) );
 
 				return authorizationResponses;
 			}
 			catch( Exception exception )
 			{
 				this.RefreshLastNetworkActivityTime();
-				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
+				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
 			}
@@ -203,25 +162,27 @@ namespace ChannelAdvisorAccess.Services.Admin
 				mark = Mark.CreateNew();
 			try
 			{
-				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString, methodParameters : localId ) );
+				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : localId ) );
 
 				var authorizationResponses = await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = await this._client.GetAuthorizationListAsync( this._credentials, localId ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result.GetAuthorizationListResult );
 					return result.GetAuthorizationListResult.ResultData;
 				} ).ConfigureAwait( false );
 
-				ChannelAdvisorLogger.LogTraceEnd( this.CreateMethodCallInfo( mark : mark, methodResult : authorizationResponses.ToJson(), additionalInfo : this.AdditionalLogInfoString, methodParameters : localId ) );
+				ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodResult : authorizationResponses.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : localId ) );
 
 				return authorizationResponses;
 			}
 			catch( Exception exception )
 			{
 				this.RefreshLastNetworkActivityTime();
-				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
+				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
 			}
@@ -233,24 +194,26 @@ namespace ChannelAdvisorAccess.Services.Admin
 				mark = Mark.CreateNew();
 			try
 			{
-				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString, methodParameters : localId.ToString() ) );
+				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : localId.ToString() ) );
 
 				var requestAccess = AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = this._client.RequestAccess( this._credentials, localId );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result );
 					return result.ResultData;
 				} );
-				ChannelAdvisorLogger.LogTraceEnd( this.CreateMethodCallInfo( mark : mark, methodResult : requestAccess.ToJson(), additionalInfo : this.AdditionalLogInfoString, methodParameters : localId.ToString() ) );
+				ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodResult : requestAccess.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : localId.ToString() ) );
 
 				return requestAccess;
 			}
 			catch( Exception exception )
 			{
 				this.RefreshLastNetworkActivityTime();
-				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
+				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
 			}
@@ -262,25 +225,27 @@ namespace ChannelAdvisorAccess.Services.Admin
 				mark = Mark.CreateNew();
 			try
 			{
-				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString, methodParameters : localId.ToString() ) );
+				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : localId.ToString() ) );
 
 				var requestAsyncResult = await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = await this._client.RequestAccessAsync( this._credentials, localId ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result.RequestAccessResult );
 					return result.RequestAccessResult.ResultData;
 				} ).ConfigureAwait( false );
 				;
-				ChannelAdvisorLogger.LogTraceEnd( this.CreateMethodCallInfo( mark : mark, methodResult : requestAsyncResult.ToJson(), additionalInfo : this.AdditionalLogInfoString, methodParameters : localId.ToString() ) );
+				ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodResult : requestAsyncResult.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : localId.ToString() ) );
 
 				return requestAsyncResult;
 			}
 			catch( Exception exception )
 			{
 				this.RefreshLastNetworkActivityTime();
-				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
+				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
 			}

--- a/src/ChannelAdvisorAccess/Services/Admin/AdminService.cs
+++ b/src/ChannelAdvisorAccess/Services/Admin/AdminService.cs
@@ -4,18 +4,16 @@ using System.Threading.Tasks;
 using ChannelAdvisorAccess.AdminService;
 using ChannelAdvisorAccess.Exceptions;
 using ChannelAdvisorAccess.Misc;
+using ChannelAdvisorAccess.Services.Items;
 using Newtonsoft.Json;
 
 namespace ChannelAdvisorAccess.Services.Admin
 {
-	public class AdminService: IAdminService
+	public class AdminService: ServiceBaseAbstr, IAdminService
 	{
 		private readonly APICredentials _credentials;
 		private readonly AdminServiceSoapClient _client;
-
-		[ JsonIgnore ]
-		public Func< string > AdditionalLogInfo{ get; set; }
-
+		
 		private string AdditionalLogInfoString
 		{
 			get
@@ -80,7 +78,9 @@ namespace ChannelAdvisorAccess.Services.Admin
 
 				AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = this._client.Ping( this._credentials );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result );
 				} );
 
@@ -88,6 +88,7 @@ namespace ChannelAdvisorAccess.Services.Admin
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -104,7 +105,9 @@ namespace ChannelAdvisorAccess.Services.Admin
 
 				await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = await this._client.PingAsync( this._credentials ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result.PingResult );
 				} ).ConfigureAwait( false );
 
@@ -112,6 +115,7 @@ namespace ChannelAdvisorAccess.Services.Admin
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -173,7 +177,9 @@ namespace ChannelAdvisorAccess.Services.Admin
 
 				var authorizationResponses = AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = this._client.GetAuthorizationList( this._credentials, localId );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result );
 					return result.ResultData;
 				} );
@@ -184,6 +190,7 @@ namespace ChannelAdvisorAccess.Services.Admin
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -200,7 +207,9 @@ namespace ChannelAdvisorAccess.Services.Admin
 
 				var authorizationResponses = await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = await this._client.GetAuthorizationListAsync( this._credentials, localId ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result.GetAuthorizationListResult );
 					return result.GetAuthorizationListResult.ResultData;
 				} ).ConfigureAwait( false );
@@ -211,6 +220,7 @@ namespace ChannelAdvisorAccess.Services.Admin
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -227,7 +237,9 @@ namespace ChannelAdvisorAccess.Services.Admin
 
 				var requestAccess = AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = this._client.RequestAccess( this._credentials, localId );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result );
 					return result.ResultData;
 				} );
@@ -237,6 +249,7 @@ namespace ChannelAdvisorAccess.Services.Admin
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -253,7 +266,9 @@ namespace ChannelAdvisorAccess.Services.Admin
 
 				var requestAsyncResult = await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = await this._client.RequestAccessAsync( this._credentials, localId ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result.RequestAccessResult );
 					return result.RequestAccessResult.ResultData;
 				} ).ConfigureAwait( false );
@@ -264,6 +279,7 @@ namespace ChannelAdvisorAccess.Services.Admin
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfoString ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;

--- a/src/ChannelAdvisorAccess/Services/ChannelAdvisorManagerExtensions.cs
+++ b/src/ChannelAdvisorAccess/Services/ChannelAdvisorManagerExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using ChannelAdvisorAccess.InventoryService;
+using ChannelAdvisorAccess.Misc;
 using ChannelAdvisorAccess.OrderService;
 using ChannelAdvisorAccess.Services.Items;
 
@@ -11,11 +12,11 @@ namespace ChannelAdvisorAccess.Services
 	public static class ChannelAdvisorManagerExtensions
 	{
 		#region Orders
-		public static IEnumerable< T > GetOrders< T >( this IChannelAdvisorManager manager, DateTime start, DateTime end, string accountId, CancellationToken token )
+		public static IEnumerable< T > GetOrders< T >( this IChannelAdvisorManager manager, DateTime start, DateTime end, string accountId, CancellationToken token, Mark mark = null )
 			where T : OrderResponseItem
 		{
 			var orderService = manager.GetOrdersServiceByAccountId( accountId );
-			return orderService.GetOrders< T >( start, end, token );
+			return orderService.GetOrders< T >( start, end, token, mark );
 		}
 
 		/// <summary>
@@ -37,18 +38,18 @@ namespace ChannelAdvisorAccess.Services
 		///	var orders = this.GetOrders&lt; OrderResponseDetailHigh >( orderCriteria );
 		/// </code>
 		/// </example>
-		public static IEnumerable< T > GetOrders< T >( this IChannelAdvisorManager manager, OrderCriteria orderCriteria, string accountId, CancellationToken token )
+		public static IEnumerable< T > GetOrders< T >( this IChannelAdvisorManager manager, OrderCriteria orderCriteria, string accountId, CancellationToken token, Mark mark = null )
 			where T : OrderResponseItem
 		{
 			var orderService = manager.GetOrdersServiceByAccountId( accountId );
-			return orderService.GetOrders< T >( orderCriteria, token );
+			return orderService.GetOrders< T >( orderCriteria, token, mark );
 		}
 
-		public static IList< T > GetOrdersList< T >( this IChannelAdvisorManager manager, DateTime start, DateTime end, string accountId, CancellationToken token )
+		public static IList< T > GetOrdersList< T >( this IChannelAdvisorManager manager, DateTime start, DateTime end, string accountId, CancellationToken token, Mark mark = null )
 			where T : OrderResponseItem
 		{
 			var orderService = manager.GetOrdersServiceByAccountId( accountId );
-			return orderService.GetOrdersList< T >( start, end, token );
+			return orderService.GetOrdersList< T >( start, end, token, mark );
 		}
 		#endregion
 
@@ -226,10 +227,10 @@ namespace ChannelAdvisorAccess.Services
 		/// <param name="trackingNumber">The tracking number.</param>
 		/// <param name="dateShipped">The date shipped when order was shipped (will be converted to UTC).</param>
 		/// <seealso href="http://developer.channeladvisor.com/display/cadn/OrderShipped"/>
-		public static void MarkOrderShipped( this IChannelAdvisorManager manager, string accountId, int orderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped )
+		public static void MarkOrderShipped( this IChannelAdvisorManager manager, string accountId, int orderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped, Mark mark = null )
 		{
 			var shippingService = manager.GetShippingServiceByAccountId( accountId );
-			shippingService.MarkOrderShipped( orderId, carrierCode, classCode, trackingNumber, dateShipped );
+			shippingService.MarkOrderShipped( orderId, carrierCode, classCode, trackingNumber, dateShipped, mark );
 		}
 		#endregion
 	}

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsService.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsService.cs
@@ -42,8 +42,6 @@ namespace ChannelAdvisorAccess.Services.Items
 			this._cache = cache;
 			this.SlidingCacheExpiration = ObjectCache.NoSlidingExpiration;
 			this._allItemsCacheKey = string.Format( "caAllItems_ID_{0}", this.AccountId );
-
-			TrackSoapClientNetworkActivity( this._client.InnerChannel );
 		}
 
 		public DateTime LastActivityTime

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsServiceDeleteItems.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsServiceDeleteItems.cs
@@ -21,7 +21,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var resultOfBoolean = this._client.DeleteInventoryItem( this._credentials, this.AccountId, sku );
+					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultOfBoolean.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 				} );
@@ -29,6 +31,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -47,7 +50,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var resultOfBoolean = await this._client.DeleteInventoryItemAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean.DeleteInventoryItemResult );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultOfBoolean.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 				} ).ConfigureAwait( false );
@@ -55,6 +60,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsServiceDeleteItems.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsServiceDeleteItems.cs
@@ -20,8 +20,8 @@ namespace ChannelAdvisorAccess.Services.Items
 
 				AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var resultOfBoolean = this._client.DeleteInventoryItem( this._credentials, this.AccountId, sku );
 					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean );
@@ -49,8 +49,8 @@ namespace ChannelAdvisorAccess.Services.Items
 
 				await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var resultOfBoolean = await this._client.DeleteInventoryItemAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean.DeleteInventoryItemResult );

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsServiceGetConfigInfo.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsServiceGetConfigInfo.cs
@@ -21,8 +21,8 @@ namespace ChannelAdvisorAccess.Services.Items
 
 				var classificationConfigurationInformations = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );					
 					var result = this._client.GetClassificationConfigurationInformation( this._credentials, this.AccountId );
 					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( result );
@@ -52,8 +52,8 @@ namespace ChannelAdvisorAccess.Services.Items
 
 				var classificationConfigurationInformations = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );					
 					var result = await this._client.GetClassificationConfigurationInformationAsync( this._credentials, this.AccountId ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( result.GetClassificationConfigurationInformationResult );
@@ -83,8 +83,8 @@ namespace ChannelAdvisorAccess.Services.Items
 
 				var distributionCenterResponses = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );					
 					var result = this._client.GetDistributionCenterList( this._credentials, this.AccountId );
 					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result );
@@ -114,8 +114,8 @@ namespace ChannelAdvisorAccess.Services.Items
 
 				var distributionCenterResponses = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );					
 					var result = await this._client.GetDistributionCenterListAsync( this._credentials, this.AccountId ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result.GetDistributionCenterListResult );

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsServiceGetConfigInfo.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsServiceGetConfigInfo.cs
@@ -22,7 +22,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var classificationConfigurationInformations = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.RefreshLastNetworkActivityTime();
 					var result = this._client.GetClassificationConfigurationInformation( this._credentials, this.AccountId );
+					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( result );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
 					return result.ResultData;
@@ -32,6 +34,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -50,7 +53,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var classificationConfigurationInformations = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.RefreshLastNetworkActivityTime();
 					var result = await this._client.GetClassificationConfigurationInformationAsync( this._credentials, this.AccountId ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( result.GetClassificationConfigurationInformationResult );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
 					return result.GetClassificationConfigurationInformationResult.ResultData;
@@ -60,6 +65,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -78,7 +84,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var distributionCenterResponses = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.RefreshLastNetworkActivityTime();
 					var result = this._client.GetDistributionCenterList( this._credentials, this.AccountId );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
 					return result.ResultData;
@@ -88,6 +96,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -106,7 +115,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var distributionCenterResponses = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.RefreshLastNetworkActivityTime();
 					var result = await this._client.GetDistributionCenterListAsync( this._credentials, this.AccountId ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result.GetDistributionCenterListResult );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
 					return result.GetDistributionCenterListResult.ResultData;
@@ -116,6 +127,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsServiceItems.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsServiceItems.cs
@@ -25,8 +25,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku.ToJson() ) );
 				var skuExist = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku.ToJson() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku.ToJson() ) );					
 					var result = this._client.DoesSkuExist( this._credentials, this.AccountId, sku );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku.ToJson() ) );
@@ -57,8 +57,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku.ToJson() ) );
 				var skuExist = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo(), methodParameters: !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku.ToJson() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo(), methodParameters: !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku.ToJson() ) );					
 					var result = await this._client.DoesSkuExistAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark: mark, methodResult: !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo: this.AdditionalLogInfo(), methodParameters: !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku.ToJson() ) );
@@ -93,8 +93,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				{
 					var doesSkuExistResponses = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () => 
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );						
 						var skusResult = this._client.DoesSkuExistList( this._credentials, this.AccountId, skusPage.ToArray() );
 						this.RefreshLastNetworkActivityTime();
 						var resultWithSuccessCheck = this.GetResultWithSuccessCheck( skusResult, skusResult.ResultData, false );
@@ -131,8 +131,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				{
 					var doesSkuExistResponsesByPage = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );						
 						var skusResult = await this._client.DoesSkuExistListAsync( this._credentials, this.AccountId, skusPage.ToArray() ).ConfigureAwait( false );
 						this.RefreshLastNetworkActivityTime();
 						var resultWithSuccessCheck = this.GetResultWithSuccessCheck( skusResult.DoesSkuExistListResult, skusResult.DoesSkuExistListResult.ResultData );
@@ -251,8 +251,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				{
 					var itemsResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );						
 						var apiResultOfArrayOfInventoryItemResponse = this._client.GetInventoryItemList( this._credentials, this.AccountId, skusPage.ToArray() );
 						this.RefreshLastNetworkActivityTime();
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfInventoryItemResponse.ToJson(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );
@@ -290,8 +290,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				{
 					var itemsResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );						
 						var getInventoryItemListResponse = await this._client.GetInventoryItemListAsync( this._credentials, this.AccountId, skusPage.ToArray() ).ConfigureAwait( false );
 						this.RefreshLastNetworkActivityTime();
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemListResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );
@@ -338,8 +338,8 @@ namespace ChannelAdvisorAccess.Services.Items
 					filter.Criteria.PageNumber += 1;
 					var itemResponse = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );						
 						var apiResultOfArrayOfInventoryItemResponse = this._client.GetFilteredInventoryItemList
 							(
 								this._credentials,
@@ -406,8 +406,8 @@ namespace ChannelAdvisorAccess.Services.Items
 					filter.Criteria.PageNumber += 1;
 					var itemResponse = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );						
 						var getFilteredInventoryItemListResponse = await this._client.GetFilteredInventoryItemListAsync
 							( this._credentials,
 								this.AccountId, filter.Criteria, filter.DetailLevel,
@@ -473,8 +473,8 @@ namespace ChannelAdvisorAccess.Services.Items
 
 					var itemResponse = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );						
 						var getFilteredInventoryItemListResponse = await this._client.GetFilteredInventoryItemListAsync( this._credentials, this.AccountId, filter.Criteria, filter.DetailLevel, filter.SortField, filter.SortDirection )
 							.ConfigureAwait( false );
 						this.RefreshLastNetworkActivityTime();
@@ -525,8 +525,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 				var attributeList = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var apiResultOfArrayOfAttributeInfo = this._client.GetInventoryItemAttributeList( this._credentials, this.AccountId, sku );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfAttributeInfo.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
@@ -557,8 +557,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 				var attributeList = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var getInventoryItemAttributeListResponse = await this._client.GetInventoryItemAttributeListAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemAttributeListResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
@@ -596,8 +596,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 				var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var apiResultOfQuantityInfoResponse = this._client.GetInventoryItemQuantityInfo( this._credentials, this.AccountId, sku );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfQuantityInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
@@ -630,8 +630,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 				var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var getInventoryItemQuantityInfoResponse = await this._client.GetInventoryItemQuantityInfoAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemQuantityInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
@@ -664,8 +664,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );					
 					var apiResultOfArrayOfClassificationConfigurationInformation = this._client.GetClassificationConfigurationInformation( this._credentials, this.AccountId );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfClassificationConfigurationInformation.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
@@ -697,8 +697,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );					
 					var getClassificationConfigurationInformationResponse = await this._client.GetClassificationConfigurationInformationAsync( this._credentials, this.AccountId ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getClassificationConfigurationInformationResponse.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
@@ -730,8 +730,8 @@ namespace ChannelAdvisorAccess.Services.Items
 
 				var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var apiResultOfStoreInfo = this._client.GetInventoryItemStoreInfo( this._credentials, this.AccountId, sku );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfStoreInfo.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
@@ -761,8 +761,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 				var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var getInventoryItemStoreInfoResponse = await this._client.GetInventoryItemStoreInfoAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemStoreInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
@@ -792,8 +792,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 				var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var apiResultOfArrayOfImageInfoResponse = this._client.GetInventoryItemImageList( this._credentials, this.AccountId, sku );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfImageInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
@@ -823,8 +823,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 				var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var getInventoryItemImageListResponse = await this._client.GetInventoryItemImageListAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemImageListResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
@@ -855,8 +855,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 				var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
-					ChannelAdvisorLogger.LogTraceStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );					
 					var apiResultOfArrayOfDistributionCenterInfoResponse = this._client.GetInventoryItemShippingInfo( this._credentials, this.AccountId, sku );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfDistributionCenterInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
@@ -886,8 +886,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 				var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var getInventoryItemShippingInfoResponse = await this._client.GetInventoryItemShippingInfoAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemShippingInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
@@ -918,8 +918,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 				var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var apiResultOfVariationInfo = this._client.GetInventoryItemVariationInfo( this._credentials, this.AccountId, sku );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfVariationInfo.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
@@ -950,8 +950,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 				var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var getInventoryItemVariationInfoResponse = await this._client.GetInventoryItemVariationInfoAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemVariationInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
@@ -990,8 +990,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 				var quantityResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var result = this._client.GetInventoryQuantity( this._credentials, this.AccountId, sku );
 					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( result );
@@ -1020,8 +1020,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
 				var quantityResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );					
 					var result = await this._client.GetInventoryQuantityAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( result.GetInventoryQuantityResult );
@@ -1072,8 +1072,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				{
 					var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );						
 						var apiResultOfArrayOfInventoryQuantityResponse = this._client.GetInventoryQuantityList( this._credentials, this.AccountId, s.ToArray() );
 						this.RefreshLastNetworkActivityTime();
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfInventoryQuantityResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );
@@ -1111,8 +1111,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				{
 					var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );						
 						var apiResultOfArrayOfInventoryQuantityResponse = await this._client.GetInventoryQuantityListAsync( this._credentials, this.AccountId, s.ToArray() ).ConfigureAwait( false );
 						this.RefreshLastNetworkActivityTime();
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfInventoryQuantityResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsServiceItems.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsServiceItems.cs
@@ -26,7 +26,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var skuExist = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku.ToJson() ) );
+					this.RefreshLastNetworkActivityTime();
 					var result = this._client.DoesSkuExist( this._credentials, this.AccountId, sku );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku.ToJson() ) );
 					return result;
 				} );
@@ -38,6 +40,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku.ToJson() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -55,7 +58,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var skuExist = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo(), methodParameters: !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku.ToJson() ) );
+					this.RefreshLastNetworkActivityTime();
 					var result = await this._client.DoesSkuExistAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark: mark, methodResult: !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo: this.AdditionalLogInfo(), methodParameters: !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku.ToJson() ) );
 					return result;
 				} ).ConfigureAwait( false );
@@ -66,6 +71,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -88,7 +94,9 @@ namespace ChannelAdvisorAccess.Services.Items
 					var doesSkuExistResponses = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () => 
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var skusResult = this._client.DoesSkuExistList( this._credentials, this.AccountId, skusPage.ToArray() );
+						this.RefreshLastNetworkActivityTime();
 						var resultWithSuccessCheck = this.GetResultWithSuccessCheck( skusResult, skusResult.ResultData, false );
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultWithSuccessCheck.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );
 						return resultWithSuccessCheck;
@@ -102,6 +110,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : skus.ToJson() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -123,7 +132,9 @@ namespace ChannelAdvisorAccess.Services.Items
 					var doesSkuExistResponsesByPage = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var skusResult = await this._client.DoesSkuExistListAsync( this._credentials, this.AccountId, skusPage.ToArray() ).ConfigureAwait( false );
+						this.RefreshLastNetworkActivityTime();
 						var resultWithSuccessCheck = this.GetResultWithSuccessCheck( skusResult.DoesSkuExistListResult, skusResult.DoesSkuExistListResult.ResultData );
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultWithSuccessCheck.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );
 						return resultWithSuccessCheck;
@@ -137,6 +148,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -240,7 +252,9 @@ namespace ChannelAdvisorAccess.Services.Items
 					var itemsResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var apiResultOfArrayOfInventoryItemResponse = this._client.GetInventoryItemList( this._credentials, this.AccountId, skusPage.ToArray() );
+						this.RefreshLastNetworkActivityTime();
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfInventoryItemResponse.ToJson(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );
 						return apiResultOfArrayOfInventoryItemResponse;
 					} );
@@ -251,6 +265,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -276,7 +291,9 @@ namespace ChannelAdvisorAccess.Services.Items
 					var itemsResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var getInventoryItemListResponse = await this._client.GetInventoryItemListAsync( this._credentials, this.AccountId, skusPage.ToArray() ).ConfigureAwait( false );
+						this.RefreshLastNetworkActivityTime();
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemListResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skusPage.ToJson() ) );
 						return getInventoryItemListResponse;
 					} ).ConfigureAwait( false );
@@ -290,6 +307,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -321,11 +339,13 @@ namespace ChannelAdvisorAccess.Services.Items
 					var itemResponse = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var apiResultOfArrayOfInventoryItemResponse = this._client.GetFilteredInventoryItemList
 							(
 								this._credentials,
 								this.AccountId, filter.Criteria, filter.DetailLevel,
 								filter.SortField, filter.SortDirection );
+						this.RefreshLastNetworkActivityTime();
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfInventoryItemResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
 						return apiResultOfArrayOfInventoryItemResponse;
 					} );
@@ -355,6 +375,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -386,10 +407,12 @@ namespace ChannelAdvisorAccess.Services.Items
 					var itemResponse = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var getFilteredInventoryItemListResponse = await this._client.GetFilteredInventoryItemListAsync
 							( this._credentials,
 								this.AccountId, filter.Criteria, filter.DetailLevel,
 								filter.SortField, filter.SortDirection ).ConfigureAwait( false );
+						this.RefreshLastNetworkActivityTime();
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getFilteredInventoryItemListResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
 						return getFilteredInventoryItemListResponse;
 					}
@@ -416,6 +439,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -450,8 +474,10 @@ namespace ChannelAdvisorAccess.Services.Items
 					var itemResponse = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var getFilteredInventoryItemListResponse = await this._client.GetFilteredInventoryItemListAsync( this._credentials, this.AccountId, filter.Criteria, filter.DetailLevel, filter.SortField, filter.SortDirection )
 							.ConfigureAwait( false );
+						this.RefreshLastNetworkActivityTime();
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getFilteredInventoryItemListResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
 						return getFilteredInventoryItemListResponse;
 					} ).ConfigureAwait( false );
@@ -482,6 +508,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -499,7 +526,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var attributeList = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var apiResultOfArrayOfAttributeInfo = this._client.GetInventoryItemAttributeList( this._credentials, this.AccountId, sku );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfAttributeInfo.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					return apiResultOfArrayOfAttributeInfo;
 				}
@@ -511,6 +540,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -528,7 +558,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var attributeList = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var getInventoryItemAttributeListResponse = await this._client.GetInventoryItemAttributeListAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemAttributeListResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					return getInventoryItemAttributeListResponse;
 				} ).ConfigureAwait( false );
@@ -540,6 +572,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -564,7 +597,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var apiResultOfQuantityInfoResponse = this._client.GetInventoryItemQuantityInfo( this._credentials, this.AccountId, sku );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfQuantityInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 
 					return apiResultOfQuantityInfoResponse;
@@ -578,6 +613,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -595,7 +631,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var getInventoryItemQuantityInfoResponse = await this._client.GetInventoryItemQuantityInfoAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemQuantityInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 
 					return getInventoryItemQuantityInfoResponse;
@@ -609,6 +647,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -626,7 +665,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.RefreshLastNetworkActivityTime();
 					var apiResultOfArrayOfClassificationConfigurationInformation = this._client.GetClassificationConfigurationInformation( this._credentials, this.AccountId );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfClassificationConfigurationInformation.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
 
 					return apiResultOfArrayOfClassificationConfigurationInformation;
@@ -639,6 +680,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -656,7 +698,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.RefreshLastNetworkActivityTime();
 					var getClassificationConfigurationInformationResponse = await this._client.GetClassificationConfigurationInformationAsync( this._credentials, this.AccountId ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getClassificationConfigurationInformationResponse.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
 					return getClassificationConfigurationInformationResponse;
 				} ).ConfigureAwait( false );
@@ -668,6 +712,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -686,7 +731,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var apiResultOfStoreInfo = this._client.GetInventoryItemStoreInfo( this._credentials, this.AccountId, sku );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfStoreInfo.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					return apiResultOfStoreInfo;
 				} );
@@ -697,6 +744,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -714,7 +762,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var getInventoryItemStoreInfoResponse = await this._client.GetInventoryItemStoreInfoAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemStoreInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					return getInventoryItemStoreInfoResponse;
 				} ).ConfigureAwait( false );
@@ -725,6 +775,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -742,7 +793,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var apiResultOfArrayOfImageInfoResponse = this._client.GetInventoryItemImageList( this._credentials, this.AccountId, sku );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfImageInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					return apiResultOfArrayOfImageInfoResponse;
 				} );
@@ -753,6 +806,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -770,7 +824,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var getInventoryItemImageListResponse = await this._client.GetInventoryItemImageListAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemImageListResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					return getInventoryItemImageListResponse;
 				} ).ConfigureAwait( false );
@@ -782,6 +838,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -799,7 +856,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
 					ChannelAdvisorLogger.LogTraceStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var apiResultOfArrayOfDistributionCenterInfoResponse = this._client.GetInventoryItemShippingInfo( this._credentials, this.AccountId, sku );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfDistributionCenterInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					return apiResultOfArrayOfDistributionCenterInfoResponse;
 				} );
@@ -810,6 +869,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -827,7 +887,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var getInventoryItemShippingInfoResponse = await this._client.GetInventoryItemShippingInfoAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemShippingInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					return getInventoryItemShippingInfoResponse;
 				} ).ConfigureAwait( false );
@@ -839,6 +901,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -856,7 +919,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var apiResultOfVariationInfo = this._client.GetInventoryItemVariationInfo( this._credentials, this.AccountId, sku );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfVariationInfo.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 
 					return apiResultOfVariationInfo;
@@ -868,6 +933,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -885,7 +951,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var getInventoryItemVariationInfoResponse = await this._client.GetInventoryItemVariationInfoAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getInventoryItemVariationInfoResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					return getInventoryItemVariationInfoResponse;
 				} ).ConfigureAwait( false );
@@ -896,6 +964,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -922,7 +991,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var quantityResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var result = this._client.GetInventoryQuantity( this._credentials, this.AccountId, sku );
+					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( result );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					return result;
@@ -932,6 +1003,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -949,7 +1021,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				var quantityResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
+					this.RefreshLastNetworkActivityTime();
 					var result = await this._client.GetInventoryQuantityAsync( this._credentials, this.AccountId, sku ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( result.GetInventoryQuantityResult );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : sku ) );
 					return result.GetInventoryQuantityResult;
@@ -959,6 +1033,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -998,7 +1073,9 @@ namespace ChannelAdvisorAccess.Services.Items
 					var requestResult = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var apiResultOfArrayOfInventoryQuantityResponse = this._client.GetInventoryQuantityList( this._credentials, this.AccountId, s.ToArray() );
+						this.RefreshLastNetworkActivityTime();
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfInventoryQuantityResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );
 						return apiResultOfArrayOfInventoryQuantityResponse;
 					} );
@@ -1013,6 +1090,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -1034,7 +1112,9 @@ namespace ChannelAdvisorAccess.Services.Items
 					var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var apiResultOfArrayOfInventoryQuantityResponse = await this._client.GetInventoryQuantityListAsync( this._credentials, this.AccountId, s.ToArray() ).ConfigureAwait( false );
+						this.RefreshLastNetworkActivityTime();
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : apiResultOfArrayOfInventoryQuantityResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : skus.ToJson() ) );
 						return apiResultOfArrayOfInventoryQuantityResponse;
 					} ).ConfigureAwait( false );
@@ -1049,6 +1129,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsServicePing.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsServicePing.cs
@@ -19,7 +19,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.RefreshLastNetworkActivityTime();
 					var result = this._client.Ping( this._credentials );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result );
 				} );
@@ -27,6 +29,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -44,7 +47,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.RefreshLastNetworkActivityTime();
 					var result = await this._client.PingAsync( this._credentials ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result.PingResult );
 				} ).ConfigureAwait( false );
@@ -52,6 +57,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsServicePing.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsServicePing.cs
@@ -18,8 +18,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );					
 					var result = this._client.Ping( this._credentials );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
@@ -46,8 +46,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );					
 					var result = await this._client.PingAsync( this._credentials ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsServiceSkus.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsServiceSkus.cs
@@ -74,10 +74,12 @@ namespace ChannelAdvisorAccess.Services.Items
 						() =>
 						{
 							ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
+							this.RefreshLastNetworkActivityTime();
 							var apiResultOfArrayOfString = this._client.GetFilteredSkuList
 								(
 									this._credentials, this.AccountId, filter.Criteria,
 									filter.SortField, filter.SortDirection );
+							this.RefreshLastNetworkActivityTime();
 							ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : apiResultOfArrayOfString.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
 
 							return apiResultOfArrayOfString;
@@ -109,6 +111,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -133,9 +136,11 @@ namespace ChannelAdvisorAccess.Services.Items
 					var itemResponse = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var getFilteredSkuListResponse = await this._client.GetFilteredSkuListAsync
 							( this._credentials, this.AccountId, filter.Criteria,
 								filter.SortField, filter.SortDirection ).ConfigureAwait( false );
+						this.RefreshLastNetworkActivityTime();
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getFilteredSkuListResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
 						return getFilteredSkuListResponse;
 					} ).ConfigureAwait( false );
@@ -163,6 +168,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -191,8 +197,10 @@ namespace ChannelAdvisorAccess.Services.Items
 					var itemResponse = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : parameters.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var getFilteredSkuListResponse = await this._client.GetFilteredSkuListAsync( this._credentials, this.AccountId, filter.Criteria, filter.SortField, filter.SortDirection )
 							.ConfigureAwait( false );
+						this.RefreshLastNetworkActivityTime();
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : getFilteredSkuListResponse.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : parameters.ToJson() ) );
 						return getFilteredSkuListResponse;
 					} ).ConfigureAwait( false );
@@ -226,6 +234,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsServiceSkus.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsServiceSkus.cs
@@ -73,8 +73,8 @@ namespace ChannelAdvisorAccess.Services.Items
 					var itemResponse = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get(
 						() =>
 						{
-							ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
 							this.RefreshLastNetworkActivityTime();
+							ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );							
 							var apiResultOfArrayOfString = this._client.GetFilteredSkuList
 								(
 									this._credentials, this.AccountId, filter.Criteria,
@@ -135,8 +135,8 @@ namespace ChannelAdvisorAccess.Services.Items
 					filter.Criteria.PageNumber += 1;
 					var itemResponse = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : filter.ToJson() ) );						
 						var getFilteredSkuListResponse = await this._client.GetFilteredSkuListAsync
 							( this._credentials, this.AccountId, filter.Criteria,
 								filter.SortField, filter.SortDirection ).ConfigureAwait( false );
@@ -196,8 +196,8 @@ namespace ChannelAdvisorAccess.Services.Items
 
 					var itemResponse = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : parameters.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : parameters.ToJson() ) );						
 						var getFilteredSkuListResponse = await this._client.GetFilteredSkuListAsync( this._credentials, this.AccountId, filter.Criteria, filter.SortField, filter.SortDirection )
 							.ConfigureAwait( false );
 						this.RefreshLastNetworkActivityTime();

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsServiceUpdateItems.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsServiceUpdateItems.cs
@@ -31,7 +31,10 @@ namespace ChannelAdvisorAccess.Services.Items
 					if( !isCreateNew && !this.DoesSkuExist( item.Sku, token, mark ) )
 						return;
 
+					this.RefreshLastNetworkActivityTime();
 					var resultOfBoolean = this._client.SynchInventoryItem( this._credentials, this.AccountId, item );
+					this.RefreshLastNetworkActivityTime();
+
 					CheckCaSuccess( resultOfBoolean );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultOfBoolean.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : parameters.ToJson() ) );
 				} );
@@ -39,6 +42,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -62,7 +66,9 @@ namespace ChannelAdvisorAccess.Services.Items
 					if( !isCreateNew && !( await this.DoesSkuExistAsync( item.Sku, token, mark ).ConfigureAwait( false ) ) )
 						return;
 
+					this.RefreshLastNetworkActivityTime();
 					var resultOfBoolean = await this._client.SynchInventoryItemAsync( this._credentials, this.AccountId, item ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean.SynchInventoryItemResult );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultOfBoolean.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : parameters.ToJson() ) );
 				} ).ConfigureAwait( false );
@@ -70,6 +76,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -99,7 +106,9 @@ namespace ChannelAdvisorAccess.Services.Items
 					AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : i.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var resultOfBoolean = this._client.SynchInventoryItemList( this._credentials, this.AccountId, i.ToArray() );
+						this.RefreshLastNetworkActivityTime();
 						CheckCaSuccess( resultOfBoolean );
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultOfBoolean.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : i.ToJson() ) );
 					} );
@@ -108,6 +117,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -136,7 +146,9 @@ namespace ChannelAdvisorAccess.Services.Items
 					await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : i.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var resultOfBoolean = await this._client.SynchInventoryItemListAsync( this._credentials, this.AccountId, i.ToArray() ).ConfigureAwait( false );
+						this.RefreshLastNetworkActivityTime();
 						CheckCaSuccess( resultOfBoolean.SynchInventoryItemListResult );
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultOfBoolean.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : i.ToJson() ) );
 					} ).ConfigureAwait( false );
@@ -145,6 +157,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -163,7 +176,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemQuantityAndPrice.ToJson() ) );
+					this.RefreshLastNetworkActivityTime();
 					var resultOfBoolean = this._client.UpdateInventoryItemQuantityAndPrice( this._credentials, this.AccountId, itemQuantityAndPrice );
+					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultOfBoolean.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemQuantityAndPrice.ToJson() ) );
 				} );
@@ -171,6 +186,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -189,7 +205,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemQuantityAndPrice.ToJson() ) );
+					this.RefreshLastNetworkActivityTime();
 					var resultOfBoolean = await this._client.UpdateInventoryItemQuantityAndPriceAsync( this._credentials, this.AccountId, itemQuantityAndPrice ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean.UpdateInventoryItemQuantityAndPriceResult );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultOfBoolean.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemQuantityAndPrice.ToJson() ) );
 				} ).ConfigureAwait( false );
@@ -197,6 +215,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -218,7 +237,9 @@ namespace ChannelAdvisorAccess.Services.Items
 					AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemsPage.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var resultOfBoolean = this._client.UpdateInventoryItemQuantityAndPriceList( this._credentials, this.AccountId, itemsPage.ToArray() );
+						this.RefreshLastNetworkActivityTime();
 						CheckCaSuccess( resultOfBoolean );
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultOfBoolean.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemsPage.ToJson() ) );
 					} );
@@ -228,6 +249,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -249,7 +271,9 @@ namespace ChannelAdvisorAccess.Services.Items
 					await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemsPage.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var result = await this._client.UpdateInventoryItemQuantityAndPriceListAsync( this._credentials, this.AccountId, itemsPage.ToArray() ).ConfigureAwait( false );
+						this.RefreshLastNetworkActivityTime();
 						CheckCaSuccess( result.UpdateInventoryItemQuantityAndPriceListResult );
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : result.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemsPage.ToJson() ) );
 					} ).ConfigureAwait( false );
@@ -257,6 +281,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -282,7 +307,9 @@ namespace ChannelAdvisorAccess.Services.Items
 					AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var resultOfBoolean = this._client.RemoveLabelListFromInventoryItemList( this._credentials, this.AccountId, labels, s.ToArray(), reason );
+						this.RefreshLastNetworkActivityTime();
 						CheckCaSuccess( resultOfBoolean );
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultOfBoolean.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );
 					} );
@@ -292,6 +319,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -314,7 +342,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				await skus.DoWithPagesAsync( 500, async s => await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );
+					this.RefreshLastNetworkActivityTime();
 					var resultOfBoolean = await this._client.RemoveLabelListFromInventoryItemListAsync( this._credentials, this.AccountId, labels, s.ToArray(), reason ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean.RemoveLabelListFromInventoryItemListResult );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultOfBoolean.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );
 				} ).ConfigureAwait( false ) ).ConfigureAwait( false );
@@ -322,6 +352,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -346,7 +377,9 @@ namespace ChannelAdvisorAccess.Services.Items
 					AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 					{
 						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );
+						this.RefreshLastNetworkActivityTime();
 						var resultOfBoolean = this._client.AssignLabelListToInventoryItemList( this._credentials, this.AccountId, labels, createLabelIfNotExist, s.ToArray(), reason );
+						this.RefreshLastNetworkActivityTime();
 						CheckCaSuccess( resultOfBoolean );
 						ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultOfBoolean.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );
 					} );
@@ -355,6 +388,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;
@@ -377,7 +411,9 @@ namespace ChannelAdvisorAccess.Services.Items
 				await skus.DoWithPagesAsync( 500, async s => await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );
+					this.RefreshLastNetworkActivityTime();
 					var resultOfBoolean = await this._client.AssignLabelListToInventoryItemListAsync( this._credentials, this.AccountId, labels, createLabelIfNotExist, s.ToArray(), reason ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean.AssignLabelListToInventoryItemListResult );
 					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, methodResult : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : resultOfBoolean.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );
 				} ).ConfigureAwait( false ) ).ConfigureAwait( false );
@@ -385,6 +421,7 @@ namespace ChannelAdvisorAccess.Services.Items
 			}
 			catch( Exception exception )
 			{
+				this.RefreshLastNetworkActivityTime();
 				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
 				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
 				throw channelAdvisorException;

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsServiceUpdateItems.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsServiceUpdateItems.cs
@@ -27,11 +27,11 @@ namespace ChannelAdvisorAccess.Services.Items
 
 				AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : parameters.ToJson() ) );
 					if( !isCreateNew && !this.DoesSkuExist( item.Sku, token, mark ) )
 						return;
-
-					this.RefreshLastNetworkActivityTime();
+					
 					var resultOfBoolean = this._client.SynchInventoryItem( this._credentials, this.AccountId, item );
 					this.RefreshLastNetworkActivityTime();
 
@@ -62,11 +62,11 @@ namespace ChannelAdvisorAccess.Services.Items
 
 				await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : parameters.ToJson() ) );
 					if( !isCreateNew && !( await this.DoesSkuExistAsync( item.Sku, token, mark ).ConfigureAwait( false ) ) )
 						return;
-
-					this.RefreshLastNetworkActivityTime();
+					
 					var resultOfBoolean = await this._client.SynchInventoryItemAsync( this._credentials, this.AccountId, item ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean.SynchInventoryItemResult );
@@ -105,8 +105,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				{
 					AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : i.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : i.ToJson() ) );						
 						var resultOfBoolean = this._client.SynchInventoryItemList( this._credentials, this.AccountId, i.ToArray() );
 						this.RefreshLastNetworkActivityTime();
 						CheckCaSuccess( resultOfBoolean );
@@ -145,8 +145,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				{
 					await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : i.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : i.ToJson() ) );						
 						var resultOfBoolean = await this._client.SynchInventoryItemListAsync( this._credentials, this.AccountId, i.ToArray() ).ConfigureAwait( false );
 						this.RefreshLastNetworkActivityTime();
 						CheckCaSuccess( resultOfBoolean.SynchInventoryItemListResult );
@@ -175,8 +175,8 @@ namespace ChannelAdvisorAccess.Services.Items
 
 				AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemQuantityAndPrice.ToJson() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemQuantityAndPrice.ToJson() ) );					
 					var resultOfBoolean = this._client.UpdateInventoryItemQuantityAndPrice( this._credentials, this.AccountId, itemQuantityAndPrice );
 					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean );
@@ -204,8 +204,8 @@ namespace ChannelAdvisorAccess.Services.Items
 
 				await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemQuantityAndPrice.ToJson() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemQuantityAndPrice.ToJson() ) );					
 					var resultOfBoolean = await this._client.UpdateInventoryItemQuantityAndPriceAsync( this._credentials, this.AccountId, itemQuantityAndPrice ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean.UpdateInventoryItemQuantityAndPriceResult );
@@ -236,8 +236,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				{
 					AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemsPage.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemsPage.ToJson() ) );						
 						var resultOfBoolean = this._client.UpdateInventoryItemQuantityAndPriceList( this._credentials, this.AccountId, itemsPage.ToArray() );
 						this.RefreshLastNetworkActivityTime();
 						CheckCaSuccess( resultOfBoolean );
@@ -270,8 +270,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				{
 					await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemsPage.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : itemsPage.ToJson() ) );						
 						var result = await this._client.UpdateInventoryItemQuantityAndPriceListAsync( this._credentials, this.AccountId, itemsPage.ToArray() ).ConfigureAwait( false );
 						this.RefreshLastNetworkActivityTime();
 						CheckCaSuccess( result.UpdateInventoryItemQuantityAndPriceListResult );
@@ -306,8 +306,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				{
 					AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );						
 						var resultOfBoolean = this._client.RemoveLabelListFromInventoryItemList( this._credentials, this.AccountId, labels, s.ToArray(), reason );
 						this.RefreshLastNetworkActivityTime();
 						CheckCaSuccess( resultOfBoolean );
@@ -341,8 +341,8 @@ namespace ChannelAdvisorAccess.Services.Items
 
 				await skus.DoWithPagesAsync( 500, async s => await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );					
 					var resultOfBoolean = await this._client.RemoveLabelListFromInventoryItemListAsync( this._credentials, this.AccountId, labels, s.ToArray(), reason ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean.RemoveLabelListFromInventoryItemListResult );
@@ -376,8 +376,8 @@ namespace ChannelAdvisorAccess.Services.Items
 				{
 					AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 					{
-						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );
 						this.RefreshLastNetworkActivityTime();
+						ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );						
 						var resultOfBoolean = this._client.AssignLabelListToInventoryItemList( this._credentials, this.AccountId, labels, createLabelIfNotExist, s.ToArray(), reason );
 						this.RefreshLastNetworkActivityTime();
 						CheckCaSuccess( resultOfBoolean );
@@ -410,8 +410,8 @@ namespace ChannelAdvisorAccess.Services.Items
 
 				await skus.DoWithPagesAsync( 500, async s => await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
-					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : !this.LogDetailsEnum.HasFlag( LogDetailsEnum.LogParametersAndResultForRetry ) ? null : s.ToJson() ) );					
 					var resultOfBoolean = await this._client.AssignLabelListToInventoryItemListAsync( this._credentials, this.AccountId, labels, createLabelIfNotExist, s.ToArray(), reason ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( resultOfBoolean.AssignLabelListToInventoryItemListResult );

--- a/src/ChannelAdvisorAccess/Services/Items/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ServiceBaseAbstr.cs
@@ -44,26 +44,12 @@ namespace ChannelAdvisorAccess.Services.Items
 				return PredefinedValues.EmptyJsonObject;
 			}
 		}
-
-		protected void TrackSoapClientNetworkActivity( IClientChannel clientChannel )
-		{
-			clientChannel.Opening += TrackSoapClientNetworkActivity;
-			clientChannel.Opened += TrackSoapClientNetworkActivity;
-			clientChannel.Closing += TrackSoapClientNetworkActivity;
-			clientChannel.Closed += TrackSoapClientNetworkActivity;
-			clientChannel.Faulted += TrackSoapClientNetworkActivity;
-		}
-
-		private void TrackSoapClientNetworkActivity( object sender, EventArgs args )
-		{
-			RefreshLastNetworkActivityTime();
-		}
-
+		
 		/// <summary>
 		///	This method is used to update service's last network activity time.
 		///	It's called every time before making API request to server or after handling the response.
 		/// </summary>
-		private void RefreshLastNetworkActivityTime()
+		protected void RefreshLastNetworkActivityTime()
 		{
 			this.LastNetworkActivityTime = DateTime.UtcNow;
 		}

--- a/src/ChannelAdvisorAccess/Services/Listing/IListingService.cs
+++ b/src/ChannelAdvisorAccess/Services/Listing/IListingService.cs
@@ -1,3 +1,4 @@
+using ChannelAdvisorAccess.Misc;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -8,9 +9,9 @@ namespace ChannelAdvisorAccess.Services.Listing
 	/// </summary>
 	public interface IListingService
 	{
-		void Ping();
-		Task PingAsync();
-		void WithdrawListing( IList< string > itemSkus, string withdrawReason );
-		Task WithdrawListingAsync( IList< string > itemSkus, string withdrawReason );
+		void Ping( Mark mark = null );
+		Task PingAsync( Mark mark = null );
+		void WithdrawListing( IList< string > itemSkus, string withdrawReason, Mark mark = null );
+		Task WithdrawListingAsync( IList< string > itemSkus, string withdrawReason, Mark mark = null );
 	}
 }

--- a/src/ChannelAdvisorAccess/Services/Listing/ListingService.cs
+++ b/src/ChannelAdvisorAccess/Services/Listing/ListingService.cs
@@ -33,55 +33,132 @@ namespace ChannelAdvisorAccess.Services.Listing
 		}
 
 		#region Ping
-		public void Ping()
+		public void Ping( Mark mark = null )
 		{
-			AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
+			if( mark.IsBlank() )
+				mark = Mark.CreateNew();
+
+			try
+			{
+				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+
+				AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
+				{
+					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					var result = this._client.Ping( this._credentials );
+					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.CheckCaSuccess( result );
+				} );
+
+				ChannelAdvisorLogger.LogTraceEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+
+			}
+			catch (Exception exception)
 			{
 				this.RefreshLastNetworkActivityTime();
-				var result = this._client.Ping( this._credentials );
-				this.RefreshLastNetworkActivityTime();
-				this.CheckCaSuccess( result );
-			} );
+				var channelAdvisorException = new ChannelAdvisorException(this.CreateMethodCallInfo(mark: mark, additionalInfo: this.AdditionalLogInfo()), exception);
+				ChannelAdvisorLogger.LogTraceException(channelAdvisorException);
+				throw channelAdvisorException;
+			}
 		}
 
-		public async Task PingAsync()
+		public async Task PingAsync( Mark mark = null )
 		{
-			await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
+			if( mark.IsBlank() )
+				mark = Mark.CreateNew();
+
+			try
+			{
+				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+
+				await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
+				{
+					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					var result = await this._client.PingAsync( this._credentials ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.CheckCaSuccess( result.PingResult );
+				} ).ConfigureAwait( false );
+
+				ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+			}
+			catch ( Exception exception )
 			{
 				this.RefreshLastNetworkActivityTime();
-				var result = await this._client.PingAsync( this._credentials ).ConfigureAwait( false );
-				this.RefreshLastNetworkActivityTime();
-				this.CheckCaSuccess( result.PingResult );
-			} ).ConfigureAwait( false );
+				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo() ), exception );
+				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
+				throw channelAdvisorException;
+			}
 		}
 		#endregion
 
-		public void WithdrawListing( IList< string > itemSkus, string withdrawReason )
+		public void WithdrawListing( IList< string > itemSkus, string withdrawReason, Mark mark = null )
 		{
-			if( itemSkus == null || itemSkus.Count == 0 )
-				return;
+			if( mark.IsBlank() )
+				mark = Mark.CreateNew();
 
-			itemSkus.DoWithPages( 100, s => AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
+			try
+			{				
+				if( itemSkus == null || itemSkus.Count == 0 )
+					return;
+
+				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+
+				itemSkus.DoWithPages( 100, s => AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
+				{
+					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					var result = this._client.WithdrawListings( this._credentials, this.AccountId, s.ToArray(), null, withdrawReason );
+					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.CheckCaSuccess( result );
+				} ) );
+
+				ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+			}
+			catch ( Exception exception )
 			{
 				this.RefreshLastNetworkActivityTime();
-				var result = this._client.WithdrawListings( this._credentials, this.AccountId, s.ToArray(), null, withdrawReason );
-				this.RefreshLastNetworkActivityTime();
-				this.CheckCaSuccess( result );
-			} ) );
+				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo() ), exception );
+				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
+				throw channelAdvisorException;
+			}
 		}
 
-		public async Task WithdrawListingAsync( IList< string > itemSkus, string withdrawReason )
+		public async Task WithdrawListingAsync( IList< string > itemSkus, string withdrawReason, Mark mark = null )
 		{
-			if( itemSkus == null || itemSkus.Count == 0 )
-				return;
+			if( mark.IsBlank() )
+				mark = Mark.CreateNew();
 
-			await itemSkus.DoWithPagesAsync( 100, async s => await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
+			try
+			{
+				if( itemSkus == null || itemSkus.Count == 0 )
+					return;
+
+				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+
+				await itemSkus.DoWithPagesAsync( 100, async s => await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
+				{
+					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					var result = await this._client.WithdrawListingsAsync( this._credentials, this.AccountId, s.ToArray(), null, withdrawReason ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+					this.CheckCaSuccess( result.WithdrawListingsResult );
+				} ).ConfigureAwait( false ) ).ConfigureAwait( false );
+
+				ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
+			}
+			catch ( Exception exception )
 			{
 				this.RefreshLastNetworkActivityTime();
-				var result = await this._client.WithdrawListingsAsync( this._credentials, this.AccountId, s.ToArray(), null, withdrawReason ).ConfigureAwait( false );
-				this.RefreshLastNetworkActivityTime();
-				this.CheckCaSuccess( result.WithdrawListingsResult );
-			} ).ConfigureAwait( false ) ).ConfigureAwait( false );
+				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo() ), exception );
+				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
+				throw channelAdvisorException;
+			}
 		}
 
 		private void CheckCaSuccess( APIResultOfInt32 result )

--- a/src/ChannelAdvisorAccess/Services/Listing/ListingService.cs
+++ b/src/ChannelAdvisorAccess/Services/Listing/ListingService.cs
@@ -5,20 +5,18 @@ using System.Threading.Tasks;
 using ChannelAdvisorAccess.Exceptions;
 using ChannelAdvisorAccess.ListingService;
 using ChannelAdvisorAccess.Misc;
+using ChannelAdvisorAccess.Services.Items;
 using Netco.Extensions;
 using Newtonsoft.Json;
 
 namespace ChannelAdvisorAccess.Services.Listing
 {
-	public class ListingService: IListingService
+	public class ListingService: ServiceBaseAbstr, IListingService
 	{
 		private readonly APICredentials _credentials;
 		private readonly ListingServiceSoapClient _client;
 		public string Name{ get; private set; }
-		public string AccountId{ get; private set; }
-
-		[ JsonIgnore ]
-		public Func< string > AdditionalLogInfo{ get; set; }
+		public string AccountId{ get; private set; }		
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ListingService"/> class.
@@ -39,7 +37,9 @@ namespace ChannelAdvisorAccess.Services.Listing
 		{
 			AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var result = this._client.Ping( this._credentials );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( result );
 			} );
 		}
@@ -48,7 +48,9 @@ namespace ChannelAdvisorAccess.Services.Listing
 		{
 			await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var result = await this._client.PingAsync( this._credentials ).ConfigureAwait( false );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( result.PingResult );
 			} ).ConfigureAwait( false );
 		}
@@ -61,7 +63,9 @@ namespace ChannelAdvisorAccess.Services.Listing
 
 			itemSkus.DoWithPages( 100, s => AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var result = this._client.WithdrawListings( this._credentials, this.AccountId, s.ToArray(), null, withdrawReason );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( result );
 			} ) );
 		}
@@ -73,7 +77,9 @@ namespace ChannelAdvisorAccess.Services.Listing
 
 			await itemSkus.DoWithPagesAsync( 100, async s => await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var result = await this._client.WithdrawListingsAsync( this._credentials, this.AccountId, s.ToArray(), null, withdrawReason ).ConfigureAwait( false );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( result.WithdrawListingsResult );
 			} ).ConfigureAwait( false ) ).ConfigureAwait( false );
 		}

--- a/src/ChannelAdvisorAccess/Services/Orders/IOrdersService.cs
+++ b/src/ChannelAdvisorAccess/Services/Orders/IOrdersService.cs
@@ -21,9 +21,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 		/// </summary>
 		string AccountId{ get; }
 
-		void Ping();
+		void Ping( Mark mark = null );
 
-		Task PingAsync();
+		Task PingAsync( Mark mark = null );
 
 		/// <summary>
 		/// Gets the orders.
@@ -32,7 +32,7 @@ namespace ChannelAdvisorAccess.Services.Orders
 		/// <param name="endDate">The end date.</param>
 		/// <returns>Iterator to go over orders 1 order at a time.</returns>
 		/// <remarks>The best way to process orders is to use <c>foreach</c></remarks>
-		IEnumerable< T > GetOrders< T >( DateTime startDate, DateTime endDate, CancellationToken token )
+		IEnumerable< T > GetOrders< T >( DateTime startDate, DateTime endDate, CancellationToken token, Mark mark = null )
 			where T : OrderResponseItem;
 
 		/// <summary>
@@ -42,7 +42,7 @@ namespace ChannelAdvisorAccess.Services.Orders
 		/// <param name="endDate">The end date.</param>
 		/// <returns>Iterator to go over orders 1 order at a time.</returns>
 		/// <remarks>The best way to process orders is to use <c>foreach</c></remarks>
-		Task< IEnumerable< T > > GetOrdersAsync< T >( DateTime startDate, DateTime endDate, CancellationToken token )
+		Task< IEnumerable< T > > GetOrdersAsync< T >( DateTime startDate, DateTime endDate, CancellationToken token, Mark mark = null )
 			where T : OrderResponseItem;
 
 		/// <summary>
@@ -52,7 +52,7 @@ namespace ChannelAdvisorAccess.Services.Orders
 		/// <param name="startDate">The start date.</param>
 		/// <param name="endDate">The end date.</param>
 		/// <returns>Downloads all orders matching the date and returns them in a list.</returns>
-		IList< T > GetOrdersList< T >( DateTime startDate, DateTime endDate, CancellationToken token )
+		IList< T > GetOrdersList< T >( DateTime startDate, DateTime endDate, CancellationToken token, Mark mark = null )
 			where T : OrderResponseItem;
 
 		/// <summary>
@@ -61,7 +61,7 @@ namespace ChannelAdvisorAccess.Services.Orders
 		/// <typeparam name="T">Type of order response.</typeparam>
 		/// <param name="orderCriteria">The order criteria.</param>
 		/// <returns>Orders matching supplied criteria.</returns>
-		IEnumerable< T > GetOrders< T >( OrderCriteria orderCriteria, CancellationToken token )
+		IEnumerable< T > GetOrders< T >( OrderCriteria orderCriteria, CancellationToken token, Mark mark = null )
 			where T : OrderResponseItem;
 
 		/// <summary>
@@ -77,18 +77,18 @@ namespace ChannelAdvisorAccess.Services.Orders
 		/// <summary>Updates the order list.</summary>
 		/// <param name="orderUpdates">The order updates.</param>
 		/// <returns>Result of updates.</returns>
-		IEnumerable< OrderUpdateResponse > UpdateOrderList( OrderUpdateSubmit[] orderUpdates, CancellationToken token );
+		IEnumerable< OrderUpdateResponse > UpdateOrderList( OrderUpdateSubmit[] orderUpdates, CancellationToken token, Mark mark = null );
 
-		Task< IEnumerable< OrderUpdateResponse > > UpdateOrderListAsync( OrderUpdateSubmit[] orderUpdates, CancellationToken token );
+		Task< IEnumerable< OrderUpdateResponse > > UpdateOrderListAsync( OrderUpdateSubmit[] orderUpdates, CancellationToken token, Mark mark = null );
 
 		/// <summary>
 		/// Submits the order.
 		/// </summary>
 		/// <param name="orderSubmit">The order submit.</param>
 		/// <returns>New order CA id.</returns>
-		int SubmitOrder( OrderSubmit orderSubmit, CancellationToken token );
+		int SubmitOrder( OrderSubmit orderSubmit, CancellationToken token, Mark mark = null );
 
-		Task< int > SubmitOrderAsync( OrderSubmit orderSubmit, CancellationToken token );
+		Task< int > SubmitOrderAsync( OrderSubmit orderSubmit, CancellationToken token, Mark mark = null );
 
 		/// <summary>
 		///	This property can be used by the client to monitor the last access library's network activity time.

--- a/src/ChannelAdvisorAccess/Services/Orders/OrdersService.cs
+++ b/src/ChannelAdvisorAccess/Services/Orders/OrdersService.cs
@@ -289,8 +289,8 @@ namespace ChannelAdvisorAccess.Services.Orders
 				var numberAttempt = 0;
 				while( numberAttempt < MaxUnexpectedAttempt )
 				{
-					ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : orderCriteria.ToJson() ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : orderCriteria.ToJson() ) );					
 					var answer = await this._client.GetOrderListAsync( this._credentials, this.AccountId, orderCriteria ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodResult : answer.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : orderCriteria.ToJson() ) );

--- a/src/ChannelAdvisorAccess/Services/Orders/OrdersService.cs
+++ b/src/ChannelAdvisorAccess/Services/Orders/OrdersService.cs
@@ -49,10 +49,7 @@ namespace ChannelAdvisorAccess.Services.Orders
 			this._client = new OrderServiceSoapClient();
 			
 			this._fulfillmentServiceCredentials = new FulfillmentService.APICredentials { DeveloperKey = this._credentials.DeveloperKey, Password = this._credentials.Password };
-			this._fulfillmentServiceClient = new FulfillmentService.FulfillmentServiceSoapClient();
-
-			TrackSoapClientNetworkActivity( this._client.InnerChannel );
-			TrackSoapClientNetworkActivity( this._fulfillmentServiceClient.InnerChannel );
+			this._fulfillmentServiceClient = new FulfillmentService.FulfillmentServiceSoapClient();			
 		}
 
 		#region Ping
@@ -60,7 +57,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 		{
 			AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var result = this._client.Ping( this._credentials );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( result );
 			} );
 		}
@@ -69,7 +68,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 		{
 			await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var result = await this._client.PingAsync( this._credentials ).ConfigureAwait( false );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( result.PingResult );
 			} ).ConfigureAwait( false );
 		}
@@ -159,7 +160,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 		{
 			return AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var results = this._client.GetOrderList( this._credentials, this.AccountId, orderCriteria );
+				this.RefreshLastNetworkActivityTime();
 				CheckCaSuccess( results );
 				var resultData = results.ResultData ?? new OrderResponseItem[ 0 ];
 
@@ -184,7 +187,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 				var numberAttempt = 0;
 				while( numberAttempt < MaxUnexpectedAttempt )
 				{
+					this.RefreshLastNetworkActivityTime();
 					var answer = this._client.GetOrderList( this._credentials, this.AccountId, orderCriteria );
+					this.RefreshLastNetworkActivityTime();
 					if( answer.Status == ResultStatus.Success )
 					{
 						result.AddRange( answer.ResultData );
@@ -257,7 +262,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 		{
 			return await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo, mark : mark ) ).Get( async () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var results = await this._client.GetOrderListAsync( this._credentials, this.AccountId, orderCriteria ).ConfigureAwait( false );
+				this.RefreshLastNetworkActivityTime();
 				CheckCaSuccess( results.GetOrderListResult );
 				var resultData = results.GetOrderListResult.ResultData ?? new OrderResponseItem[ 0 ];
 
@@ -283,7 +290,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 				while( numberAttempt < MaxUnexpectedAttempt )
 				{
 					ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : orderCriteria.ToJson() ) );
+					this.RefreshLastNetworkActivityTime();
 					var answer = await this._client.GetOrderListAsync( this._credentials, this.AccountId, orderCriteria ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodResult : answer.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : orderCriteria.ToJson() ) );
 					if( answer.GetOrderListResult.Status == ResultStatus.Success )
 					{
@@ -313,7 +322,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 		{
 			return AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var apiResults = this._client.SubmitOrder( this._credentials, this.AccountId, orderSubmit );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( apiResults );
 				return apiResults.ResultData;
 			} );
@@ -323,7 +334,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 		{
 			return await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var apiResults = await this._client.SubmitOrderAsync( this._credentials, this.AccountId, orderSubmit ).ConfigureAwait( false );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( apiResults.SubmitOrderResult );
 				return apiResults.SubmitOrderResult.ResultData;
 			} ).ConfigureAwait( false );
@@ -350,7 +363,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 			{
 				var ordersFulfillment = AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var results = this._fulfillmentServiceClient.GetOrderFulfillmentDetailList( this._fulfillmentServiceCredentials, this.AccountId, part.ToArray(), null );
+					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( results );
 					var resultData = results.ResultData ?? new FulfillmentService.OrderFulfillmentResponse[ 0 ];
 
@@ -385,7 +400,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 			{
 				var ordersFulfillment = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var results = await this._fulfillmentServiceClient.GetOrderFulfillmentDetailListAsync( this._fulfillmentServiceCredentials, this.AccountId, part.ToArray(), null ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					CheckCaSuccess( results.GetOrderFulfillmentDetailListResult );
 					var resultData = results.GetOrderFulfillmentDetailListResult.ResultData ?? new FulfillmentService.OrderFulfillmentResponse[ 0 ];
 
@@ -436,7 +453,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 		{
 			return AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var results = this._client.UpdateOrderList( this._credentials, this.AccountId, orderUpdates );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( results );
 				return results.ResultData;
 			} );
@@ -446,7 +465,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 		{
 			return await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var results = await this._client.UpdateOrderListAsync( this._credentials, this.AccountId, orderUpdates ).ConfigureAwait( false );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( results.UpdateOrderListResult );
 				return results.UpdateOrderListResult.ResultData;
 			} ).ConfigureAwait( false );

--- a/src/ChannelAdvisorAccess/Services/Shipping/IShippingService.cs
+++ b/src/ChannelAdvisorAccess/Services/Shipping/IShippingService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using ChannelAdvisorAccess.Misc;
 using ChannelAdvisorAccess.ShippingService;
 
 namespace ChannelAdvisorAccess.Services.Shipping
@@ -9,25 +10,25 @@ namespace ChannelAdvisorAccess.Services.Shipping
 	{
 		string Name { get; }
 		string AccountId { get; }
-		void Ping();
-		Task PingAsync();
-		void MarkOrderShipped( int orderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped );
-		Task MarkOrderShippedAsync( int orderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped );
-		void MarkOrderShipped( string clientOrderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped );
-		Task MarkOrderShippedAsync( string clientOrderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped );
-		void MarkOrderShipped( int orderId, PartialShipmentContents partialShipmentContents );
-		Task MarkOrderShippedAsync( int orderId, PartialShipmentContents partialShipmentContents );
-		void MarkOrderShipped( string clientOrderId, PartialShipmentContents partialShipmentContents );
-		Task MarkOrderShippedAsync( string clientOrderId, PartialShipmentContents partialShipmentContents );
-		void SubmitOrderShipmentList( IEnumerable< OrderShipment > orderShipments );
-		Task SubmitOrderShipmentListAsync( IEnumerable< OrderShipment > orderShipments );
-		OrderShipmentHistoryResponse[] GetOrderShipmentHistoryList( int[] orderIdList );
-		Task< OrderShipmentHistoryResponse[] > GetOrderShipmentHistoryListAsync( int[] orderIdList );
-		OrderShipmentHistoryResponse[] GetOrderShipmentHistoryList( string[] clientOrderIdentifierList );
-		Task< OrderShipmentHistoryResponse[] > GetOrderShipmentHistoryListAsync( string[] clientOrderIdentifierList );
-		OrderShipmentHistoryResponse[] GetOrderShipmentHistoryList( int[] orderIdList, string[] clientOrderIdentifierList );
-		Task< OrderShipmentHistoryResponse[] > GetOrderShipmentHistoryListAsync( int[] orderIdList, string[] clientOrderIdentifierList );
-		ShippingCarrier[] GetShippingCarrierList();
-		Task< ShippingCarrier[] > GetShippingCarrierListAsync();
+		void Ping( Mark mark = null );
+		Task PingAsync( Mark mark = null );
+		void MarkOrderShipped( int orderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped, Mark mark = null );
+		Task MarkOrderShippedAsync( int orderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped, Mark mark = null );
+		void MarkOrderShipped( string clientOrderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped, Mark mark = null );
+		Task MarkOrderShippedAsync( string clientOrderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped, Mark mark = null );
+		void MarkOrderShipped( int orderId, PartialShipmentContents partialShipmentContents, Mark mark = null );
+		Task MarkOrderShippedAsync( int orderId, PartialShipmentContents partialShipmentContents, Mark mark = null );
+		void MarkOrderShipped( string clientOrderId, PartialShipmentContents partialShipmentContents, Mark mark = null );
+		Task MarkOrderShippedAsync( string clientOrderId, PartialShipmentContents partialShipmentContents, Mark mark = null );
+		void SubmitOrderShipmentList( IEnumerable< OrderShipment > orderShipments, Mark mark = null );
+		Task SubmitOrderShipmentListAsync( IEnumerable< OrderShipment > orderShipments, Mark mark = null );
+		OrderShipmentHistoryResponse[] GetOrderShipmentHistoryList( int[] orderIdList, Mark mark = null );
+		Task< OrderShipmentHistoryResponse[] > GetOrderShipmentHistoryListAsync( int[] orderIdList, Mark mark = null );
+		OrderShipmentHistoryResponse[] GetOrderShipmentHistoryList( string[] clientOrderIdentifierList, Mark mark = null );
+		Task< OrderShipmentHistoryResponse[] > GetOrderShipmentHistoryListAsync( string[] clientOrderIdentifierList, Mark mark = null );
+		OrderShipmentHistoryResponse[] GetOrderShipmentHistoryList( int[] orderIdList, string[] clientOrderIdentifierList, Mark mark = null );
+		Task< OrderShipmentHistoryResponse[] > GetOrderShipmentHistoryListAsync( int[] orderIdList, string[] clientOrderIdentifierList, Mark mark = null );
+		ShippingCarrier[] GetShippingCarrierList( Mark mark = null );
+		Task< ShippingCarrier[] > GetShippingCarrierListAsync( Mark mark = null );
 	}
 }

--- a/src/ChannelAdvisorAccess/Services/Shipping/ShippingService.cs
+++ b/src/ChannelAdvisorAccess/Services/Shipping/ShippingService.cs
@@ -34,64 +34,74 @@ namespace ChannelAdvisorAccess.Services.Shipping
 		public string AccountId{ get; private set; }
 
 		#region Ping
-		public void Ping()
+		public void Ping( Mark mark = null )
 		{
 			AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 			{
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				var result = this._client.Ping( this._credentials );
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				this.CheckCaSuccess( result );
 			} );
 		}
 
-		public async Task PingAsync()
+		public async Task PingAsync( Mark mark = null )
 		{
 			await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 			{
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				var result = await this._client.PingAsync( this._credentials ).ConfigureAwait( false );
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				this.CheckCaSuccess( result.PingResult );
 			} ).ConfigureAwait( false );
 		}
 		#endregion
 
 		#region Mark Order Shipped
-		public void MarkOrderShipped( int orderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped )
+		public void MarkOrderShipped( int orderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped, Mark mark = null )
 		{
 			try
 			{
 				AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = this._client.SubmitOrderShipmentList( this._credentials, this.AccountId, CreateShipmentByOrderId( orderId, carrierCode, classCode, trackingNumber, dateShipped ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result );
 				} );
 			}
 			catch( Exception e )
 			{
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceException( new ChannelAdvisorException( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo() ), e ) );
 				throw new MarkOrderShippedException( orderId.ToString( CultureInfo.InvariantCulture ), this.AccountId, carrierCode, classCode, trackingNumber, e );
 			}
 		}
 
-		public async Task MarkOrderShippedAsync( int orderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped )
+		public async Task MarkOrderShippedAsync( int orderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped, Mark mark = null )
 		{
 			try
 			{
 				await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = await this._client.SubmitOrderShipmentListAsync( this._credentials, this.AccountId, CreateShipmentByOrderId( orderId, carrierCode, classCode, trackingNumber, dateShipped ) ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result.SubmitOrderShipmentListResult );
 				} ).ConfigureAwait( false );
 			}
 			catch( Exception e )
 			{
-				this.RefreshLastNetworkActivityTime();
+				this.RefreshLastNetworkActivityTime();				
+				ChannelAdvisorLogger.LogTraceException( new ChannelAdvisorException( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo() ), e ) );
 				throw new MarkOrderShippedException( orderId.ToString( CultureInfo.InvariantCulture ), this.AccountId, carrierCode, classCode, trackingNumber, e );
 			}
 		}
@@ -115,40 +125,46 @@ namespace ChannelAdvisorAccess.Services.Shipping
 			};
 		}
 
-		public void MarkOrderShipped( string clientOrderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped )
+		public void MarkOrderShipped( string clientOrderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped, Mark mark = null )
 		{
 			try
 			{
 				AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = this._client.SubmitOrderShipmentList( this._credentials, this.AccountId, CreateShipmentByClientId( clientOrderId, carrierCode, classCode, trackingNumber, dateShipped ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result );
 				} );
 			}
 			catch( Exception e )
 			{
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceException( new ChannelAdvisorException( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo() ), e ) );
 				throw new MarkOrderShippedException( clientOrderId, this.AccountId, carrierCode, classCode, trackingNumber, e );
 			}
 		}
 
-		public async Task MarkOrderShippedAsync( string clientOrderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped )
+		public async Task MarkOrderShippedAsync( string clientOrderId, string carrierCode, string classCode, string trackingNumber, DateTime dateShipped, Mark mark = null )
 		{
 			try
 			{
 				await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = await this._client.SubmitOrderShipmentListAsync( this._credentials, this.AccountId, CreateShipmentByClientId( clientOrderId, carrierCode, classCode, trackingNumber, dateShipped ) ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result.SubmitOrderShipmentListResult );
 				} ).ConfigureAwait( false );
 			}
 			catch( Exception e )
 			{
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceException( new ChannelAdvisorException( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo() ), e ) );
 				throw new MarkOrderShippedException( clientOrderId, this.AccountId, carrierCode, classCode, trackingNumber, e );
 			}
 		}
@@ -172,40 +188,46 @@ namespace ChannelAdvisorAccess.Services.Shipping
 			};
 		}
 
-		public void MarkOrderShipped( int orderId, PartialShipmentContents partialShipmentContents )
+		public void MarkOrderShipped( int orderId, PartialShipmentContents partialShipmentContents, Mark mark = null )
 		{
 			try
 			{
 				AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = this._client.SubmitOrderShipmentList( this._credentials, this.AccountId, CreatePartialShipmentByOrderId( orderId, partialShipmentContents ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result );
 				} );
 			}
 			catch( Exception e )
 			{
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceException( new ChannelAdvisorException( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo() ), e ) );
 				throw new MarkOrderShippedException( orderId.ToString( CultureInfo.InvariantCulture ), this.AccountId, partialShipmentContents.CarrierCode, partialShipmentContents.ClassCode, partialShipmentContents.TrackingNumber, e );
 			}
 		}
 
-		public async Task MarkOrderShippedAsync( int orderId, PartialShipmentContents partialShipmentContents )
+		public async Task MarkOrderShippedAsync( int orderId, PartialShipmentContents partialShipmentContents, Mark mark = null )
 		{
 			try
 			{
 				await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = await this._client.SubmitOrderShipmentListAsync( this._credentials, this.AccountId, CreatePartialShipmentByOrderId( orderId, partialShipmentContents ) ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result.SubmitOrderShipmentListResult );
 				} ).ConfigureAwait( false );
 			}
 			catch( Exception e )
 			{
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceException( new ChannelAdvisorException( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo() ), e ) );
 				throw new MarkOrderShippedException( orderId.ToString( CultureInfo.InvariantCulture ), this.AccountId, partialShipmentContents.CarrierCode, partialShipmentContents.ClassCode, partialShipmentContents.TrackingNumber, e );
 			}
 		}
@@ -223,40 +245,46 @@ namespace ChannelAdvisorAccess.Services.Shipping
 			};
 		}
 
-		public void MarkOrderShipped( string clientOrderId, PartialShipmentContents partialShipmentContents )
+		public void MarkOrderShipped( string clientOrderId, PartialShipmentContents partialShipmentContents, Mark mark = null )
 		{
 			try
 			{
 				AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = this._client.SubmitOrderShipmentList( this._credentials, this.AccountId, CreatePartialShipmentByClientId( clientOrderId, partialShipmentContents ) );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result );
 				} );
 			}
 			catch( Exception e )
 			{
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceException( new ChannelAdvisorException( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo() ), e ) );
 				throw new MarkOrderShippedException( clientOrderId, this.AccountId, partialShipmentContents.CarrierCode, partialShipmentContents.ClassCode, partialShipmentContents.TrackingNumber, e );
 			}
 		}
 
-		public async Task MarkOrderShippedAsync( string clientOrderId, PartialShipmentContents partialShipmentContents )
+		public async Task MarkOrderShippedAsync( string clientOrderId, PartialShipmentContents partialShipmentContents, Mark mark = null )
 		{
 			try
 			{
 				await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					var result = await this._client.SubmitOrderShipmentListAsync( this._credentials, this.AccountId, CreatePartialShipmentByClientId( clientOrderId, partialShipmentContents ) ).ConfigureAwait( false );
 					this.RefreshLastNetworkActivityTime();
+					ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 					this.CheckCaSuccess( result.SubmitOrderShipmentListResult );
 				} ).ConfigureAwait( false );
 			}
 			catch( Exception e )
 			{
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceException( new ChannelAdvisorException( this.CreateMethodCallInfo( mark: mark, additionalInfo: this.AdditionalLogInfo() ), e ) );
 				throw new MarkOrderShippedException( clientOrderId, this.AccountId, partialShipmentContents.CarrierCode, partialShipmentContents.ClassCode, partialShipmentContents.TrackingNumber, e );
 			}
 		}
@@ -275,86 +303,98 @@ namespace ChannelAdvisorAccess.Services.Shipping
 		}
 		#endregion
 
-		public void SubmitOrderShipmentList( IEnumerable< OrderShipment > orderShipments )
+		public void SubmitOrderShipmentList( IEnumerable< OrderShipment > orderShipments, Mark mark = null )
 		{
 			orderShipments.DoWithPages( 50, p => AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 			{
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				var result = this._client.SubmitOrderShipmentList( this._credentials, this.AccountId, p.ToArray() );
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				this.CheckCaSuccess( result );
 			} ) );
 		}
 
-		public async Task SubmitOrderShipmentListAsync( IEnumerable< OrderShipment > orderShipments )
+		public async Task SubmitOrderShipmentListAsync( IEnumerable< OrderShipment > orderShipments, Mark mark = null )
 		{
 			await orderShipments.DoWithPagesAsync( 50, async p => await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 			{
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				var result = await this._client.SubmitOrderShipmentListAsync( this._credentials, this.AccountId, p.ToArray() ).ConfigureAwait( false );
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				this.CheckCaSuccess( result.SubmitOrderShipmentListResult );
 			} ).ConfigureAwait( false ) ).ConfigureAwait( false );
 		}
 
-		public OrderShipmentHistoryResponse[] GetOrderShipmentHistoryList( int[] orderIdList )
+		public OrderShipmentHistoryResponse[] GetOrderShipmentHistoryList( int[] orderIdList, Mark mark = null )
 		{
-			return this.GetOrderShipmentHistoryList( orderIdList, new string[] { } );
+			return this.GetOrderShipmentHistoryList( orderIdList, new string[] { }, mark );
 		}
 
-		public async Task< OrderShipmentHistoryResponse[] > GetOrderShipmentHistoryListAsync( int[] orderIdList )
+		public async Task< OrderShipmentHistoryResponse[] > GetOrderShipmentHistoryListAsync( int[] orderIdList, Mark mark = null )
 		{
-			return await this.GetOrderShipmentHistoryListAsync( orderIdList, new string[] { } ).ConfigureAwait( false );
+			return await this.GetOrderShipmentHistoryListAsync( orderIdList, new string[] { }, mark ).ConfigureAwait( false );
 		}
 
-		public OrderShipmentHistoryResponse[] GetOrderShipmentHistoryList( string[] clientOrderIdentifierList )
+		public OrderShipmentHistoryResponse[] GetOrderShipmentHistoryList( string[] clientOrderIdentifierList, Mark mark = null )
 		{
-			return this.GetOrderShipmentHistoryList( new int[] { }, clientOrderIdentifierList );
+			return this.GetOrderShipmentHistoryList( new int[] { }, clientOrderIdentifierList, mark );
 		}
 
-		public async Task< OrderShipmentHistoryResponse[] > GetOrderShipmentHistoryListAsync( string[] clientOrderIdentifierList )
+		public async Task< OrderShipmentHistoryResponse[] > GetOrderShipmentHistoryListAsync( string[] clientOrderIdentifierList, Mark mark = null )
 		{
-			return await this.GetOrderShipmentHistoryListAsync( new int[] { }, clientOrderIdentifierList ).ConfigureAwait( false );
+			return await this.GetOrderShipmentHistoryListAsync( new int[] { }, clientOrderIdentifierList, mark ).ConfigureAwait( false );
 		}
 
-		public OrderShipmentHistoryResponse[] GetOrderShipmentHistoryList( int[] orderIdList, string[] clientOrderIdentifierList )
+		public OrderShipmentHistoryResponse[] GetOrderShipmentHistoryList( int[] orderIdList, string[] clientOrderIdentifierList, Mark mark = null )
 		{
 			return AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 			{
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				var result = this._client.GetOrderShipmentHistoryList( this._credentials, this.AccountId, orderIdList, clientOrderIdentifierList );
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				this.CheckCaSuccess( result );
 				return result.ResultData;
 			} );
 		}
 
-		public async Task< OrderShipmentHistoryResponse[] > GetOrderShipmentHistoryListAsync( int[] orderIdList, string[] clientOrderIdentifierList )
+		public async Task< OrderShipmentHistoryResponse[] > GetOrderShipmentHistoryListAsync( int[] orderIdList, string[] clientOrderIdentifierList, Mark mark = null )
 		{
 			return await AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 			{
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				var result = await this._client.GetOrderShipmentHistoryListAsync( this._credentials, this.AccountId, orderIdList, clientOrderIdentifierList ).ConfigureAwait( false );
 				this.RefreshLastNetworkActivityTime();
+				ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 				this.CheckCaSuccess( result.GetOrderShipmentHistoryListResult );
 				return result.GetOrderShipmentHistoryListResult.ResultData;
 			} ).ConfigureAwait( false );
 		}
 
-		public ShippingCarrier[] GetShippingCarrierList()
+		public ShippingCarrier[] GetShippingCarrierList( Mark mark = null )
 		{
 			this.RefreshLastNetworkActivityTime();
+			ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 			var result = this._client.GetShippingCarrierList( this._credentials, this.AccountId );
 			this.RefreshLastNetworkActivityTime();
+			ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 			this.CheckCaSuccess( result );
 			return result.ResultData;
 		}
 
-		public async Task< ShippingCarrier[] > GetShippingCarrierListAsync()
+		public async Task< ShippingCarrier[] > GetShippingCarrierListAsync( Mark mark = null )
 		{
 			this.RefreshLastNetworkActivityTime();
+			ChannelAdvisorLogger.LogTraceRetryStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 			var result = await this._client.GetShippingCarrierListAsync( this._credentials, this.AccountId ).ConfigureAwait( false );
 			this.RefreshLastNetworkActivityTime();
+			ChannelAdvisorLogger.LogTraceRetryEnd( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ) );
 			this.CheckCaSuccess( result.GetShippingCarrierListResult );
 			return result.GetShippingCarrierListResult.ResultData;
 		}

--- a/src/ChannelAdvisorAccess/Services/Shipping/ShippingService.cs
+++ b/src/ChannelAdvisorAccess/Services/Shipping/ShippingService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using ChannelAdvisorAccess.Exceptions;
 using ChannelAdvisorAccess.Misc;
+using ChannelAdvisorAccess.Services.Items;
 using ChannelAdvisorAccess.ShippingService;
 using Netco.Extensions;
 using Netco.Logging;
@@ -12,14 +13,11 @@ using Newtonsoft.Json;
 
 namespace ChannelAdvisorAccess.Services.Shipping
 {
-	public class ShippingService: IShippingService
+	public class ShippingService: ServiceBaseAbstr, IShippingService
 	{
 		private readonly APICredentials _credentials;
 		private readonly ShippingServiceSoapClient _client;
-
-		[ JsonIgnore ]
-		public Func< string > AdditionalLogInfo{ get; set; }
-
+		
 		public ShippingService( APICredentials credentials, string accountId )
 		{
 			this._credentials = credentials;
@@ -40,7 +38,9 @@ namespace ChannelAdvisorAccess.Services.Shipping
 		{
 			AP.CreateQuery( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var result = this._client.Ping( this._credentials );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( result );
 			} );
 		}
@@ -49,7 +49,9 @@ namespace ChannelAdvisorAccess.Services.Shipping
 		{
 			await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var result = await this._client.PingAsync( this._credentials ).ConfigureAwait( false );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( result.PingResult );
 			} ).ConfigureAwait( false );
 		}
@@ -62,12 +64,15 @@ namespace ChannelAdvisorAccess.Services.Shipping
 			{
 				AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = this._client.SubmitOrderShipmentList( this._credentials, this.AccountId, CreateShipmentByOrderId( orderId, carrierCode, classCode, trackingNumber, dateShipped ) );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result );
 				} );
 			}
 			catch( Exception e )
 			{
+				this.RefreshLastNetworkActivityTime();
 				throw new MarkOrderShippedException( orderId.ToString( CultureInfo.InvariantCulture ), this.AccountId, carrierCode, classCode, trackingNumber, e );
 			}
 		}
@@ -78,12 +83,15 @@ namespace ChannelAdvisorAccess.Services.Shipping
 			{
 				await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = await this._client.SubmitOrderShipmentListAsync( this._credentials, this.AccountId, CreateShipmentByOrderId( orderId, carrierCode, classCode, trackingNumber, dateShipped ) ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result.SubmitOrderShipmentListResult );
 				} ).ConfigureAwait( false );
 			}
 			catch( Exception e )
 			{
+				this.RefreshLastNetworkActivityTime();
 				throw new MarkOrderShippedException( orderId.ToString( CultureInfo.InvariantCulture ), this.AccountId, carrierCode, classCode, trackingNumber, e );
 			}
 		}
@@ -113,12 +121,15 @@ namespace ChannelAdvisorAccess.Services.Shipping
 			{
 				AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = this._client.SubmitOrderShipmentList( this._credentials, this.AccountId, CreateShipmentByClientId( clientOrderId, carrierCode, classCode, trackingNumber, dateShipped ) );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result );
 				} );
 			}
 			catch( Exception e )
 			{
+				this.RefreshLastNetworkActivityTime();
 				throw new MarkOrderShippedException( clientOrderId, this.AccountId, carrierCode, classCode, trackingNumber, e );
 			}
 		}
@@ -129,12 +140,15 @@ namespace ChannelAdvisorAccess.Services.Shipping
 			{
 				await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = await this._client.SubmitOrderShipmentListAsync( this._credentials, this.AccountId, CreateShipmentByClientId( clientOrderId, carrierCode, classCode, trackingNumber, dateShipped ) ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result.SubmitOrderShipmentListResult );
 				} ).ConfigureAwait( false );
 			}
 			catch( Exception e )
 			{
+				this.RefreshLastNetworkActivityTime();
 				throw new MarkOrderShippedException( clientOrderId, this.AccountId, carrierCode, classCode, trackingNumber, e );
 			}
 		}
@@ -164,12 +178,15 @@ namespace ChannelAdvisorAccess.Services.Shipping
 			{
 				AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = this._client.SubmitOrderShipmentList( this._credentials, this.AccountId, CreatePartialShipmentByOrderId( orderId, partialShipmentContents ) );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result );
 				} );
 			}
 			catch( Exception e )
 			{
+				this.RefreshLastNetworkActivityTime();
 				throw new MarkOrderShippedException( orderId.ToString( CultureInfo.InvariantCulture ), this.AccountId, partialShipmentContents.CarrierCode, partialShipmentContents.ClassCode, partialShipmentContents.TrackingNumber, e );
 			}
 		}
@@ -180,12 +197,15 @@ namespace ChannelAdvisorAccess.Services.Shipping
 			{
 				await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = await this._client.SubmitOrderShipmentListAsync( this._credentials, this.AccountId, CreatePartialShipmentByOrderId( orderId, partialShipmentContents ) ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result.SubmitOrderShipmentListResult );
 				} ).ConfigureAwait( false );
 			}
 			catch( Exception e )
 			{
+				this.RefreshLastNetworkActivityTime();
 				throw new MarkOrderShippedException( orderId.ToString( CultureInfo.InvariantCulture ), this.AccountId, partialShipmentContents.CarrierCode, partialShipmentContents.ClassCode, partialShipmentContents.TrackingNumber, e );
 			}
 		}
@@ -209,12 +229,15 @@ namespace ChannelAdvisorAccess.Services.Shipping
 			{
 				AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = this._client.SubmitOrderShipmentList( this._credentials, this.AccountId, CreatePartialShipmentByClientId( clientOrderId, partialShipmentContents ) );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result );
 				} );
 			}
 			catch( Exception e )
 			{
+				this.RefreshLastNetworkActivityTime();
 				throw new MarkOrderShippedException( clientOrderId, this.AccountId, partialShipmentContents.CarrierCode, partialShipmentContents.ClassCode, partialShipmentContents.TrackingNumber, e );
 			}
 		}
@@ -225,12 +248,15 @@ namespace ChannelAdvisorAccess.Services.Shipping
 			{
 				await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 				{
+					this.RefreshLastNetworkActivityTime();
 					var result = await this._client.SubmitOrderShipmentListAsync( this._credentials, this.AccountId, CreatePartialShipmentByClientId( clientOrderId, partialShipmentContents ) ).ConfigureAwait( false );
+					this.RefreshLastNetworkActivityTime();
 					this.CheckCaSuccess( result.SubmitOrderShipmentListResult );
 				} ).ConfigureAwait( false );
 			}
 			catch( Exception e )
 			{
+				this.RefreshLastNetworkActivityTime();
 				throw new MarkOrderShippedException( clientOrderId, this.AccountId, partialShipmentContents.CarrierCode, partialShipmentContents.ClassCode, partialShipmentContents.TrackingNumber, e );
 			}
 		}
@@ -253,7 +279,9 @@ namespace ChannelAdvisorAccess.Services.Shipping
 		{
 			orderShipments.DoWithPages( 50, p => AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var result = this._client.SubmitOrderShipmentList( this._credentials, this.AccountId, p.ToArray() );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( result );
 			} ) );
 		}
@@ -262,7 +290,9 @@ namespace ChannelAdvisorAccess.Services.Shipping
 		{
 			await orderShipments.DoWithPagesAsync( 50, async p => await AP.CreateSubmitAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Do( async () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var result = await this._client.SubmitOrderShipmentListAsync( this._credentials, this.AccountId, p.ToArray() ).ConfigureAwait( false );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( result.SubmitOrderShipmentListResult );
 			} ).ConfigureAwait( false ) ).ConfigureAwait( false );
 		}
@@ -291,7 +321,9 @@ namespace ChannelAdvisorAccess.Services.Shipping
 		{
 			return AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var result = this._client.GetOrderShipmentHistoryList( this._credentials, this.AccountId, orderIdList, clientOrderIdentifierList );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( result );
 				return result.ResultData;
 			} );
@@ -301,7 +333,9 @@ namespace ChannelAdvisorAccess.Services.Shipping
 		{
 			return await AP.CreateSubmit( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 			{
+				this.RefreshLastNetworkActivityTime();
 				var result = await this._client.GetOrderShipmentHistoryListAsync( this._credentials, this.AccountId, orderIdList, clientOrderIdentifierList ).ConfigureAwait( false );
+				this.RefreshLastNetworkActivityTime();
 				this.CheckCaSuccess( result.GetOrderShipmentHistoryListResult );
 				return result.GetOrderShipmentHistoryListResult.ResultData;
 			} ).ConfigureAwait( false );
@@ -309,14 +343,18 @@ namespace ChannelAdvisorAccess.Services.Shipping
 
 		public ShippingCarrier[] GetShippingCarrierList()
 		{
+			this.RefreshLastNetworkActivityTime();
 			var result = this._client.GetShippingCarrierList( this._credentials, this.AccountId );
+			this.RefreshLastNetworkActivityTime();
 			this.CheckCaSuccess( result );
 			return result.ResultData;
 		}
 
 		public async Task< ShippingCarrier[] > GetShippingCarrierListAsync()
 		{
+			this.RefreshLastNetworkActivityTime();
 			var result = await this._client.GetShippingCarrierListAsync( this._credentials, this.AccountId ).ConfigureAwait( false );
+			this.RefreshLastNetworkActivityTime();
 			this.CheckCaSuccess( result.GetShippingCarrierListResult );
 			return result.GetShippingCarrierListResult.ResultData;
 		}

--- a/src/ChannelAdvisorAccessTests/Inventory/DistributionCenterTests.cs
+++ b/src/ChannelAdvisorAccessTests/Inventory/DistributionCenterTests.cs
@@ -17,7 +17,8 @@ namespace ChannelAdvisorAccessTests.Inventory
 
 			//------------ Assert
 			dcList.Length.Should().BeGreaterThan( 0 );
-			dcList.Select(dc => dc.DistributionCenterCode).Should().Contain(TestDistributionCenterCode);
+			dcList.Select( dc => dc.DistributionCenterCode ).Should().Contain( TestDistributionCenterCode );
+			this.ItemsService.LastActivityTime.Should().NotBe( this.serviceLastActivityDateTime );
 		}
 	}
 }

--- a/src/ChannelAdvisorAccessTests/Inventory/ItemsServiceTests.cs
+++ b/src/ChannelAdvisorAccessTests/Inventory/ItemsServiceTests.cs
@@ -29,6 +29,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 
 			//------------ Assert
 			this.ItemsService.GetAvailableQuantity( TestSku, CancellationToken.None ).Should().Be( 5 );
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		private static InventoryItemQuantityAndPrice CreateItemQuantityAndPrice( int quantity )
@@ -50,6 +51,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 			this.ItemsService.Ping();
 
 			//------------ Assert
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -61,6 +63,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 			this.ItemsService.PingAsync().GetAwaiter().GetResult();
 
 			//------------ Assert
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -73,6 +76,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 
 			//------------ Assert
 			result.Should().BeTrue();
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -84,7 +88,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 			var result = this.ItemsService.DoesSkuExist( TestSku + Guid.NewGuid(), CancellationToken.None );
 
 			//------------ Assert
-			result.Should().BeFalse();
+			result.Should().BeFalse();			
 		}
 
 		[ Test ]
@@ -97,6 +101,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 
 			//------------ Assert
 			result.Should().BeTrue();
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -227,6 +232,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 
 			//------------ Assert
 			result.Should().NotBeNullOrEmpty();
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -242,6 +248,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 			result.Should().NotBeNullOrEmpty();
 			result.Count().ShouldBeEquivalentTo( 1 );
 			result.First().Sku.ToLower().ShouldBeEquivalentTo( TestSku.ToLower() );
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -257,6 +264,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 			result.Should().NotBeNullOrEmpty();
 			result.Count().ShouldBeEquivalentTo( 1 );
 			result.First().Sku.ToLower().ShouldBeEquivalentTo( TestSku.ToLower() );
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -270,6 +278,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 			//------------ Assert
 			result.Should().NotBeNull();
 			result.Available.Should().BeGreaterThan( 0 );
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -283,6 +292,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 			//------------ Assert
 			result.Should().NotBeNull();
 			result.Available.Should().BeGreaterThan( 0 );
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -295,6 +305,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 
 			//------------ Assert
 			result.Should().NotBeNullOrEmpty();
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -307,6 +318,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 
 			//------------ Assert
 			result.Should().NotBeNullOrEmpty();
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -319,6 +331,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 
 			//------------ Assert
 			result.Should().NotBeNull();
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -330,7 +343,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 			var result = this.ItemsService.GetStoreInfoAsync( TestSku, CancellationToken.None ).GetAwaiter().GetResult();
 
 			//------------ Assert
-			result.Should().NotBeNull();
+			result.Should().NotBeNull();			
 		}
 
 		[ Test ]
@@ -353,6 +366,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 			//------------ Assert
 			result.Should().NotBeNull();
 			result.Length.Should().BeGreaterThan( 0 );
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -366,6 +380,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 			//------------ Assert
 			result.Should().NotBeNull();
 			result.Length.Should().BeGreaterThan( 0 );
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -378,6 +393,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 
 			//------------ Assert
 			result.Should().NotBeNull();
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -390,6 +406,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 
 			//------------ Assert
 			result.Should().NotBeNull();
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -410,6 +427,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 			result[ 1 ].SKU.ShouldBeEquivalentTo( incorrectSku );
 			result[ 1 ].MessageCode.Should().BeGreaterThan( 0 );
 			result[ 1 ].Quantity.ShouldBeEquivalentTo( 0 );
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -430,6 +448,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 			result[ 1 ].SKU.ShouldBeEquivalentTo( incorrectSku );
 			result[ 1 ].MessageCode.Should().BeGreaterThan( 0 );
 			result[ 1 ].Quantity.ShouldBeEquivalentTo( 0 );
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -446,6 +465,11 @@ namespace ChannelAdvisorAccessTests.Inventory
 			var existingsSkus = this.ItemsService.DoSkusExistAsync( allSkus, CancellationToken.None ).GetAwaiter().GetResult();
 			System.Diagnostics.Debug.WriteLine( ( DateTime.Now - startTime ).TotalSeconds );
 			//------------ Assert
+		}
+
+		private void ValidateLastActivityDateTimeUpdated()
+		{ 
+			this.ItemsService.LastActivityTime.Should().NotBe( this.serviceLastActivityDateTime );			
 		}
 
 		//IEnumerable< InventoryItemResponse > GetFilteredItems( ItemsFilter filter, Mark mark = null );

--- a/src/ChannelAdvisorAccessTests/Orders/OrdersServiceTests.cs
+++ b/src/ChannelAdvisorAccessTests/Orders/OrdersServiceTests.cs
@@ -12,8 +12,9 @@ namespace ChannelAdvisorAccessTests.Inventory
 	[ TestFixture ]
 	public class OrdersServiceTests: TestsBase
 	{
-		protected const int TestOrderId = 182948;
-		protected const int TestOrderId2 = 182949;
+		protected const int TestOrderId = 185936;
+		protected const int TestOrderId2 = 185938;
+		protected const int TestOrderId3 = 185939;		
 
 		[ Test ]
 		public async Task GetOrdersAsync()
@@ -26,6 +27,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 			var result = await this.OrdersService.GetOrdersAsync< OrderResponseDetailComplete >( criteria, CancellationToken.None );
 
 			result.Should().NotBeEmpty();
+			ValidateLastActivityDateTimeUpdated();
 		}
 
 		[ Test ]
@@ -33,7 +35,7 @@ namespace ChannelAdvisorAccessTests.Inventory
 		{
 			var criteria = new OrderCriteria
 			{
-				OrderIDList = new int[] { TestOrderId, TestOrderId2 },
+				OrderIDList = new int[] { TestOrderId3 },
 				DetailLevel = DetailLevelTypes.Complete
 			};
 
@@ -50,11 +52,11 @@ namespace ChannelAdvisorAccessTests.Inventory
 		{
 			var criteria = new OrderCriteria
 			{
-				OrderIDList = new int[] { TestOrderId, TestOrderId2 },
+				OrderIDList = new int[] { TestOrderId3 },
 				DetailLevel = DetailLevelTypes.Complete
 			};
 
-			var result = await this.OrdersService.GetOrdersAsync<OrderResponseDetailComplete>( criteria, CancellationToken.None );
+			var result = await this.OrdersService.GetOrdersAsync< OrderResponseDetailComplete >( criteria, CancellationToken.None );
 
 			OrderCart shoppingCart = result.First().ShoppingCart;
 			//Always returned as 0 from the CA api
@@ -91,6 +93,11 @@ namespace ChannelAdvisorAccessTests.Inventory
 			var result = await this.OrdersService.GetOrdersAsync< OrderResponseDetailComplete >( criteria, CancellationToken.None );
 
 			this.OrdersService.LastActivityTime.Should().BeAfter( activityTimeBeforeMakingAnyRequest );
+		}
+
+		private void ValidateLastActivityDateTimeUpdated()
+		{
+			this.OrdersService.LastActivityTime.Should().NotBe( this.serviceLastActivityDateTime );			
 		}
 	}
 }

--- a/src/ChannelAdvisorAccessTests/TestsBase.cs
+++ b/src/ChannelAdvisorAccessTests/TestsBase.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Runtime.Caching;
 using ChannelAdvisorAccess.Services;
 using ChannelAdvisorAccess.Services.Admin;
@@ -16,6 +17,7 @@ namespace ChannelAdvisorAccessTests
 	{
 		protected const string TestDistributionCenterCode = "Louisville";
 		protected const string TestSku = "testSku1";
+		protected DateTime serviceLastActivityDateTime = DateTime.Now;
 
 		[ SetUp ]
 		public void Init()
@@ -26,6 +28,7 @@ namespace ChannelAdvisorAccessTests
 			this.ListingService = factory.CreateListingService( "test", Credentials.AccountId );
 			this.OrdersService = factory.CreateOrdersService( "test", Credentials.AccountId );
 			this.ShippingService = factory.CreateShippingService( "test", Credentials.AccountId );
+			this.serviceLastActivityDateTime = DateTime.Now;
 		}
 
 		public IShippingService ShippingService{ get; private set; }

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.12.1.0" ) ]
+[ assembly : AssemblyVersion( "8.13.0.0" ) ]


### PR DESCRIPTION
Channel Advisor SOAP implements the SOAP Client for http interactions and has event handlers (Opening, Opened, Closing, Closed, Faulted) that update the LastNetworkActivityTime.

I found out that for loop http requests (for example when calling soapClient.DoesSkuExistList inside foreach in the DoSkusExist method), the update actually happens only once during the first iteration and does not work further.

I don't think we can do anything about it other than slightly change the implementation and update LastNetworkActivityTime manually before and after the call and on error (as it was implemented for Channel Advisor REST services).