### PR TITLE
2022-01-03  RLS-2860 GUARD-2307 ChannelAdvisor soap client memory leaks

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -75,7 +75,7 @@ task NuGet Package, Version, {
 <package>
 	<metadata>
 		<id>$project_name</id>
-		<version>$Version-beta</version>
+		<version>$Version</version>
 		<authors>Agile Harbor</authors>
 		<owners>Agile Harbor</owners>
 		<projectUrl>https://github.com/agileharbor/$project_name</projectUrl>

--- a/src/ChannelAdvisorAccess/REST/Services/Items/ItemsService.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/Items/ItemsService.cs
@@ -1405,8 +1405,12 @@ namespace ChannelAdvisorAccess.REST.Services.Items
 			throw new NotImplementedException();
 		}
 
-        public void Dispose()
-        {            
-        }
-    }
+		/// <summary>
+		/// Dispose method to implement the interfaces IItemsService -> IDisposable
+		/// it's empty because nothing to dispose for REST methods
+		/// </summary>
+		public void Dispose()
+		{
+		}
+	}
 }

--- a/src/ChannelAdvisorAccess/REST/Services/Items/ItemsService.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/Items/ItemsService.cs
@@ -1,5 +1,4 @@
-﻿using ChannelAdvisorAccess.Constants;
-using ChannelAdvisorAccess.Exceptions;
+﻿using ChannelAdvisorAccess.Exceptions;
 using ChannelAdvisorAccess.Misc;
 using ChannelAdvisorAccess.REST.Models;
 using ChannelAdvisorAccess.Services.Items;
@@ -18,9 +17,7 @@ using ICSharpCode.SharpZipLib.Zip;
 using System.IO;
 using System.Text;
 using CsvHelper;
-using System.Collections.Concurrent;
 using System.Net;
-using System.Globalization;
 using System.Threading;
 
 namespace ChannelAdvisorAccess.REST.Services.Items
@@ -1407,5 +1404,9 @@ namespace ChannelAdvisorAccess.REST.Services.Items
 		{
 			throw new NotImplementedException();
 		}
-	}
+
+        public void Dispose()
+        {            
+        }
+    }
 }

--- a/src/ChannelAdvisorAccess/REST/Services/Orders/OrdersService.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/Orders/OrdersService.cs
@@ -247,6 +247,10 @@ namespace ChannelAdvisorAccess.REST.Services.Orders
 			throw new NotImplementedException();
 		}
 
+		/// <summary>
+		/// Dispose method to implement the interfaces IItemsService -> IDisposable
+		/// it's empty because nothing to dispose for REST methods
+		/// </summary>
 		public void Dispose()
 		{
 		}

--- a/src/ChannelAdvisorAccess/REST/Services/Orders/OrdersService.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/Orders/OrdersService.cs
@@ -246,5 +246,9 @@ namespace ChannelAdvisorAccess.REST.Services.Orders
 		{
 			throw new NotImplementedException();
 		}
+
+		public void Dispose()
+		{
+		}
 	}
 }

--- a/src/ChannelAdvisorAccess/Services/Admin/AdminService.cs
+++ b/src/ChannelAdvisorAccess/Services/Admin/AdminService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using ChannelAdvisorAccess.AdminService;
 using ChannelAdvisorAccess.Exceptions;
@@ -8,7 +7,7 @@ using ChannelAdvisorAccess.Services.Items;
 
 namespace ChannelAdvisorAccess.Services.Admin
 {
-	public class AdminService: ServiceBaseAbstr, IAdminService
+	public class AdminService: ServiceBaseAbstr, IAdminService, IDisposable
 	{
 		private readonly APICredentials _credentials;
 		private readonly AdminServiceSoapClient _client;
@@ -268,5 +267,15 @@ namespace ChannelAdvisorAccess.Services.Admin
 			if( results.Status != ResultStatus.Success )
 				throw new ChannelAdvisorException( results.MessageCode, results.Message );
 		}
+
+		#region IDisposable implementation
+
+		public void Dispose()
+		{
+			Dispose( _client, true );
+			GC.SuppressFinalize( this );
+		}
+
+		#endregion
 	}
 }

--- a/src/ChannelAdvisorAccess/Services/Admin/IAdminService.cs
+++ b/src/ChannelAdvisorAccess/Services/Admin/IAdminService.cs
@@ -1,10 +1,11 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using ChannelAdvisorAccess.AdminService;
 using ChannelAdvisorAccess.Misc;
 
 namespace ChannelAdvisorAccess.Services.Admin
 {
-	public interface IAdminService
+	public interface IAdminService : IDisposable
 	{
 		/// <summary>
 		/// Gets all authorization records

--- a/src/ChannelAdvisorAccess/Services/Items/IItemsService.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/IItemsService.cs
@@ -8,7 +8,7 @@ using ChannelAdvisorAccess.REST.Models;
 
 namespace ChannelAdvisorAccess.Services.Items
 {
-	public interface IItemsService
+	public interface IItemsService : IDisposable
 	{
 		/// <summary>
 		/// Gets the account name.

--- a/src/ChannelAdvisorAccess/Services/Items/ItemsService.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsService.cs
@@ -213,5 +213,15 @@ namespace ChannelAdvisorAccess.Services.Items
 				throw new ChannelAdvisorException( result.MessageCode, result.Message );
 		}
 		#endregion
+
+		#region IDisposable implementation
+
+		public void Dispose()
+		{
+			Dispose( _client, true );
+			GC.SuppressFinalize( this );
+		}
+
+		#endregion
 	}
 }

--- a/src/ChannelAdvisorAccess/Services/Items/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ServiceBaseAbstr.cs
@@ -67,5 +67,37 @@ namespace ChannelAdvisorAccess.Services.Items
 		{
 			ServicePointManager.SecurityProtocol |= SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
 		}
-	}
+
+		#region IDisposable
+
+		internal bool disposedValue = false;
+
+		public bool Disposed
+		{
+			get
+			{
+				if ( !this.disposedValue )
+				{
+					return this.disposedValue;
+				}
+
+				throw new ObjectDisposedException( "CanBeDisposed" );
+			}
+		}
+
+		internal void Dispose< T >( ClientBase< T > client, bool disposing ) where T : class
+		{
+			if ( !disposedValue )
+			{
+				if ( disposing )
+				{
+					client.Close();
+				}
+
+				disposedValue = true;
+			}
+		}
+
+        #endregion
+    }
 }

--- a/src/ChannelAdvisorAccess/Services/Listing/IListingService.cs
+++ b/src/ChannelAdvisorAccess/Services/Listing/IListingService.cs
@@ -1,4 +1,5 @@
 using ChannelAdvisorAccess.Misc;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -7,7 +8,7 @@ namespace ChannelAdvisorAccess.Services.Listing
 	/// <summary>
 	/// Service to work with CA listings.
 	/// </summary>
-	public interface IListingService
+	public interface IListingService : IDisposable
 	{
 		void Ping( Mark mark = null );
 		Task PingAsync( Mark mark = null );

--- a/src/ChannelAdvisorAccess/Services/Listing/ListingService.cs
+++ b/src/ChannelAdvisorAccess/Services/Listing/ListingService.cs
@@ -172,5 +172,15 @@ namespace ChannelAdvisorAccess.Services.Listing
 			if( result.Status != ResultStatus.Success )
 				throw new ChannelAdvisorException( result.MessageCode, result.Message );
 		}
+
+		#region IDisposable implementation
+
+		public void Dispose()
+		{
+			Dispose( _client, true );
+			GC.SuppressFinalize( this );
+		}
+
+		#endregion
 	}
 }

--- a/src/ChannelAdvisorAccess/Services/Orders/IOrdersService.cs
+++ b/src/ChannelAdvisorAccess/Services/Orders/IOrdersService.cs
@@ -7,7 +7,7 @@ using ChannelAdvisorAccess.OrderService;
 
 namespace ChannelAdvisorAccess.Services.Orders
 {
-	public interface IOrdersService
+	public interface IOrdersService : IDisposable
 	{
 		/// <summary>
 		/// Gets the account name.

--- a/src/ChannelAdvisorAccess/Services/Orders/OrdersService.cs
+++ b/src/ChannelAdvisorAccess/Services/Orders/OrdersService.cs
@@ -663,5 +663,15 @@ namespace ChannelAdvisorAccess.Services.Orders
 			ChannelAdvisorLogger.LogTrace( string.Format( @"Wait by reason of error 1 (Unexpected) {0} minute(s). Attempt: {1}", time.Minutes, attempt ) );
 			await Task.Delay( time ).ConfigureAwait( false );
 		}
+
+		#region IDisposable implementation
+
+		public void Dispose()
+		{
+			Dispose( _client, true );
+			GC.SuppressFinalize( this );
+		}
+
+		#endregion
 	}
 }

--- a/src/ChannelAdvisorAccess/Services/Shipping/IShippingService.cs
+++ b/src/ChannelAdvisorAccess/Services/Shipping/IShippingService.cs
@@ -6,7 +6,7 @@ using ChannelAdvisorAccess.ShippingService;
 
 namespace ChannelAdvisorAccess.Services.Shipping
 {
-	public interface IShippingService
+	public interface IShippingService : IDisposable
 	{
 		string Name { get; }
 		string AccountId { get; }

--- a/src/ChannelAdvisorAccess/Services/Shipping/ShippingService.cs
+++ b/src/ChannelAdvisorAccess/Services/Shipping/ShippingService.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 
 namespace ChannelAdvisorAccess.Services.Shipping
 {
-	public class ShippingService: ServiceBaseAbstr, IShippingService
+	public class ShippingService: ServiceBaseAbstr, IShippingService, IDisposable
 	{
 		private readonly APICredentials _credentials;
 		private readonly ShippingServiceSoapClient _client;
@@ -434,5 +434,15 @@ namespace ChannelAdvisorAccess.Services.Shipping
 			if( result.Status != ResultStatus.Success )
 				throw new ChannelAdvisorException( result.MessageCode, result.Message );
 		}
+
+		#region IDisposable implementation
+
+		public void Dispose()
+		{
+			Dispose( _client, true );
+			GC.SuppressFinalize( this );
+		}
+
+		#endregion
 	}
 }

--- a/src/ChannelAdvisorAccessTests/Admin/AdminServiceTests.cs
+++ b/src/ChannelAdvisorAccessTests/Admin/AdminServiceTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Diagnostics;
+using ChannelAdvisorAccess.Services;
+using ChannelAdvisorAccess.Services.Admin;
+using NUnit.Framework;
+
+namespace ChannelAdvisorAccessTests.Admin
+{
+	[ TestFixture ]
+	public class AdminServiceTests : TestsBase
+	{
+		[ Test ]
+		public void AdminService_IsDisposable()
+		{
+			var factory = new ChannelAdvisorServicesFactory( Credentials.DeveloperKey, Credentials.DeveloperPassword, null, null );
+			AdminService service;
+
+			using ( service = (AdminService)factory.CreateAdminService() )
+			{
+				Debug.Assert( !service.Disposed ); // not be disposed yet
+			}
+
+			try
+			{
+				Debug.Assert( service.Disposed ); // expecting an exception.
+			}
+			catch ( Exception ex )
+			{
+				Debug.Assert( ex is ObjectDisposedException ); 
+			}
+		}
+	}
+}

--- a/src/ChannelAdvisorAccessTests/ChannelAdvisorAccessTests.csproj
+++ b/src/ChannelAdvisorAccessTests/ChannelAdvisorAccessTests.csproj
@@ -70,11 +70,14 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Admin\AdminServiceTests.cs" />
     <Compile Include="Inventory\DistributionCenterTests.cs" />
     <Compile Include="Inventory\ItemsServiceTests.cs" />
+    <Compile Include="Shipping\ShippingServiceTests.cs" />
     <Compile Include="Misc\ChannelAdvisorLoggerTests.cs" />
     <Compile Include="Misc\ChannelAdvisorTimeoutsTests.cs" />
     <Compile Include="Misc\OrderExtensionsTests.cs" />
+    <Compile Include="Listing\ListingServiceTests.cs" />
     <Compile Include="Orders\OrdersServiceTests.cs" />
     <Compile Include="REST\Inventory\DistributionCenterTests.cs" />
     <Compile Include="REST\Inventory\ItemsServiceTests.cs" />

--- a/src/ChannelAdvisorAccessTests/Inventory/ItemsServiceTests.cs
+++ b/src/ChannelAdvisorAccessTests/Inventory/ItemsServiceTests.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using ChannelAdvisorAccess.Constants;
 using ChannelAdvisorAccess.InventoryService;
+using ChannelAdvisorAccess.Services;
+using ChannelAdvisorAccess.Services.Items;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -465,6 +468,27 @@ namespace ChannelAdvisorAccessTests.Inventory
 			var existingsSkus = this.ItemsService.DoSkusExistAsync( allSkus, CancellationToken.None ).GetAwaiter().GetResult();
 			System.Diagnostics.Debug.WriteLine( ( DateTime.Now - startTime ).TotalSeconds );
 			//------------ Assert
+		}
+
+		[ Test ]
+		public void ItemsService_IsDisposable()
+		{
+			var factory = new ChannelAdvisorServicesFactory( Credentials.DeveloperKey, Credentials.DeveloperPassword, null, null );
+			ItemsService service;
+
+			using ( service = ( ItemsService )factory.CreateItemsService( "test", Credentials.AccountId ) )
+			{
+				Debug.Assert( !service.Disposed ); // not be disposed yet
+			}
+
+			try
+			{
+				Debug.Assert( service.Disposed ); // expecting an exception.
+			}
+			catch ( Exception ex )
+			{
+				Debug.Assert( ex is ObjectDisposedException ); 
+			}
 		}
 
 		private void ValidateLastActivityDateTimeUpdated()

--- a/src/ChannelAdvisorAccessTests/Listing/ListingServiceTests.cs
+++ b/src/ChannelAdvisorAccessTests/Listing/ListingServiceTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Diagnostics;
+using ChannelAdvisorAccess.Services;
+using ChannelAdvisorAccess.Services.Listing;
+using NUnit.Framework;
+
+namespace ChannelAdvisorAccessTests.Listing
+{
+	[TestFixture]
+	public class ListingServiceTests : TestsBase
+	{
+		[Test]
+		public void ListingService_IsDisposable()
+		{
+			var factory = new ChannelAdvisorServicesFactory( Credentials.DeveloperKey, Credentials.DeveloperPassword, null, null );
+			ListingService service;
+
+			using ( service = ( ListingService )factory.CreateListingService( "test", Credentials.AccountId ) )
+			{
+				Debug.Assert( !service.Disposed ); // not be disposed yet
+			}
+
+			try
+			{
+				Debug.Assert( service.Disposed ); // expecting an exception.
+			}
+			catch ( Exception ex )
+			{
+				Debug.Assert( ex is ObjectDisposedException );
+			}
+		}
+	}
+}

--- a/src/ChannelAdvisorAccessTests/Orders/OrdersServiceTests.cs
+++ b/src/ChannelAdvisorAccessTests/Orders/OrdersServiceTests.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ChannelAdvisorAccess.Constants;
 using ChannelAdvisorAccess.OrderService;
+using ChannelAdvisorAccess.Services;
+using ChannelAdvisorAccess.Services.Orders;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -93,6 +96,27 @@ namespace ChannelAdvisorAccessTests.Inventory
 			var result = await this.OrdersService.GetOrdersAsync< OrderResponseDetailComplete >( criteria, CancellationToken.None );
 
 			this.OrdersService.LastActivityTime.Should().BeAfter( activityTimeBeforeMakingAnyRequest );
+		}
+
+		[ Test ]
+		public void AdminService_IsDisposable()
+		{
+			var factory = new ChannelAdvisorServicesFactory( Credentials.DeveloperKey, Credentials.DeveloperPassword, null, null );
+			OrdersService service;
+			
+			using ( service = ( OrdersService )factory.CreateOrdersService( "test", Credentials.AccountId ) )
+			{
+				Debug.Assert( !service.Disposed ); // not be disposed yet
+			}
+
+			try
+			{
+				Debug.Assert( service.Disposed ); // expecting an exception.
+			}
+			catch ( Exception ex )
+			{
+				Debug.Assert( ex is ObjectDisposedException ); 
+			}
 		}
 
 		private void ValidateLastActivityDateTimeUpdated()

--- a/src/ChannelAdvisorAccessTests/Shipping/ShippingServiceTests.cs
+++ b/src/ChannelAdvisorAccessTests/Shipping/ShippingServiceTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Diagnostics;
+using ChannelAdvisorAccess.Services;
+using ChannelAdvisorAccess.Services.Shipping;
+using NUnit.Framework;
+
+namespace ChannelAdvisorAccessTests.Shipping
+{
+	[TestFixture]
+	public class ShippingServiceTests : TestsBase
+	{
+		[Test]
+		public void ShippingService_IsDisposable()
+		{
+			var factory = new ChannelAdvisorServicesFactory( Credentials.DeveloperKey, Credentials.DeveloperPassword, null, null );
+			ShippingService service;
+
+			using ( service = ( ShippingService )factory.CreateShippingService( "test", Credentials.AccountId ) )
+			{
+				Debug.Assert( !service.Disposed ); // not be disposed yet
+			}
+
+			try
+			{
+				Debug.Assert( service.Disposed ); // expecting an exception.
+			}
+			catch ( Exception ex )
+			{
+				Debug.Assert( ex is ObjectDisposedException );
+			}
+		}
+	}
+}

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.14.0.0" ) ]
+[ assembly : AssemblyVersion( "8.15.0.0" ) ]


### PR DESCRIPTION
IDisposable interface implemented for all SOAP services, unit tests added - please see the commit https://github.com/skuvault-integrations/channelAdvisorAccess/pull/34/commits/8edb1e86e637babaf7f27f3f4486f71ba1b6bd4e 

PS. This branch also contains the changes from other channel advisor tickets https://agileharbor.atlassian.net/browse/GUARD-2225 and https://agileharbor.atlassian.net/browse/GUARD-2226