### PR TITLE
VT-5739 ChannelAdvisor Product Sync Not Syncing Certain Products

### DIFF
--- a/src/ChannelAdvisorAccess/ChannelAdvisorAccess.csproj
+++ b/src/ChannelAdvisorAccess/ChannelAdvisorAccess.csproj
@@ -304,6 +304,7 @@
     <Compile Include="REST\Models\Infrastructure\ProductExportResponse.cs" />
     <Compile Include="REST\Models\Infrastructure\ProductExportRow.cs" />
     <Compile Include="REST\Models\MarketplaceSiteIdEnum.cs" />
+    <Compile Include="REST\Services\Items\ItemsPagingService.cs" />
     <Compile Include="REST\Shared\ActionPolicy.cs" />
     <Compile Include="REST\Shared\BatchBuilder.cs" />
     <Compile Include="REST\Shared\ChannelAdvisorTimeouts.cs" />

--- a/src/ChannelAdvisorAccess/REST/Services/Items/ItemsPagingService.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/Items/ItemsPagingService.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ChannelAdvisorAccess.Exceptions;
+using ChannelAdvisorAccess.InventoryService;
+using ChannelAdvisorAccess.Misc;
+using ChannelAdvisorAccess.REST.Models;
+using ChannelAdvisorAccess.REST.Models.Infrastructure;
+using ChannelAdvisorAccess.REST.Shared;
+using ChannelAdvisorAccess.Services.Items;
+using APICredentials = ChannelAdvisorAccess.OrderService.APICredentials;
+
+namespace ChannelAdvisorAccess.REST.Services.Items
+{
+	public class ItemsPagingService: ItemsService, IItemsService
+	{
+		/// <summary>
+		/// Rest items service with standard authorization flow
+		/// </summary>
+		/// <param name="credentials">Rest application credentials</param>
+		/// <param name="accountName">Tenant account name</param>
+		/// <param name="accessToken">Tenant access token</param>
+		/// <param name="refreshToken">Tenant refresh token</param>
+		/// <param name="timeouts"></param>
+		public ItemsPagingService( RestCredentials credentials, string accountName, string accessToken, string refreshToken, ChannelAdvisorTimeouts timeouts )
+			: base( credentials, accountName, accessToken, refreshToken, timeouts )
+		{
+		}
+
+		/// <summary>
+		/// Rest items service with soap compatible authorization flow
+		/// </summary>
+		/// <param name="credentials">Rest application credentials</param>
+		/// <param name="soapCredentials">Soap application credentials</param>
+		/// <param name="accountId">Tenant account id</param>
+		/// <param name="accountName">Tenant account name</param>
+		/// <param name="timeouts"></param>
+		public ItemsPagingService( RestCredentials credentials, APICredentials soapCredentials, string accountId, string accountName, ChannelAdvisorTimeouts timeouts )
+			: base( credentials, soapCredentials, accountId, accountName, timeouts )
+		{
+		}
+
+		/// <summary>
+		/// Gets filtered items asynchronously with extra page information
+		/// </summary>
+		/// <param name="filter"></param>
+		/// <param name="mark"></param>
+		/// <param name="token"></param>
+		/// <returns></returns>
+		public new async Task< IEnumerable< InventoryItemResponse > > GetFilteredItemsAsync( ItemsFilter filter, Mark mark, CancellationToken token = default )
+		{
+			var url = new ItemsServiceUrlBuilder().GetProductsUrl( filter, null, null );
+
+			var result = await this.GetProducts( url, mark, token : token ).ConfigureAwait( false );
+
+			return ( from product in result select product.ToInventoryItemResponse() ).ToList();
+		}
+
+		/// <summary>
+		/// Gets filtered skus asynchronously with extra page information
+		/// </summary>
+		/// <param name="filter"></param>
+		/// <param name="mark"></param>
+		/// <param name="token"></param>
+		/// <returns></returns>
+		public new async Task< List< string > > GetFilteredSkusAsync( ItemsFilter filter, Mark mark, CancellationToken token = default )
+		{
+			var url = new ItemsServiceUrlBuilder().GetProductsUrl( filter, "ID,Sku", null );
+			var result = await this.GetProducts( url, mark, this.Timeouts[ ChannelAdvisorOperationEnum.GetProductsByFilterWithIdOnlyRest ], token ).ConfigureAwait( false );
+
+			return result.Select( item => item.Sku ).ToList();
+		}
+
+		/// <summary>
+		/// Gets products
+		/// </summary>
+		/// <param name="url"></param>
+		/// <param name="mark"></param>
+		/// <param name="operationTimeout"></param>
+		/// <param name="token"></param>
+		/// <returns></returns>
+		private async Task< List< Product > > GetProducts( string url, Mark mark, int? operationTimeout = null, CancellationToken token = default )
+		{
+			var result = new List< Product >();
+
+			var nextLink = url;
+			while( !string.IsNullOrEmpty( nextLink ) )
+				try
+				{
+					ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : url ) );
+
+					var resultByPage = await this.GetEntityAsync< ODataResponse< Product > >( nextLink, mark, operationTimeout, token );
+					nextLink = resultByPage.NextLink;
+
+					result.AddRange( resultByPage.Value );
+
+					ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo(
+						mark : mark,
+						methodParameters : url,
+						methodResult : resultByPage.ToJson(),
+						additionalInfo : this.AdditionalLogInfo() ) );
+				}
+				catch( Exception exception )
+				{
+					var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
+					ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
+					throw channelAdvisorException;
+				}
+
+			return result;
+		}
+	}
+}

--- a/src/ChannelAdvisorAccess/REST/Services/Items/ItemsPagingService.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/Items/ItemsPagingService.cs
@@ -16,6 +16,8 @@ namespace ChannelAdvisorAccess.REST.Services.Items
 {
 	public class ItemsPagingService: ItemsService, IItemsService
 	{
+		private const int NumberProductsForLogging = 500 * 1000;
+		
 		/// <summary>
 		/// Rest items service with standard authorization flow
 		/// </summary>
@@ -97,6 +99,11 @@ namespace ChannelAdvisorAccess.REST.Services.Items
 
 					result.AddRange( resultByPage.Value );
 
+					if( result.Count > NumberProductsForLogging )
+					{
+						ChannelAdvisorLogger.Log().Info( $"[ChannelAdvisor] Product Sync request for '{this.AccountId}' try to receive more than {NumberProductsForLogging} products: {result.Count}" );
+					}
+					
 					ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo(
 						mark : mark,
 						methodParameters : url,

--- a/src/ChannelAdvisorAccess/REST/Services/Items/ItemsPagingService.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/Items/ItemsPagingService.cs
@@ -86,8 +86,9 @@ namespace ChannelAdvisorAccess.REST.Services.Items
 			var result = new List< Product >();
 
 			var nextLink = url;
-			while( !string.IsNullOrEmpty( nextLink ) )
-				try
+			try
+			{
+				while( !string.IsNullOrEmpty( nextLink ) )
 				{
 					ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : url ) );
 
@@ -102,12 +103,13 @@ namespace ChannelAdvisorAccess.REST.Services.Items
 						methodResult : resultByPage.ToJson(),
 						additionalInfo : this.AdditionalLogInfo() ) );
 				}
-				catch( Exception exception )
-				{
-					var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
-					ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
-					throw channelAdvisorException;
-				}
+			}
+			catch( Exception exception )
+			{
+				var channelAdvisorException = new ChannelAdvisorException( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo() ), exception );
+				ChannelAdvisorLogger.LogTraceException( channelAdvisorException );
+				throw channelAdvisorException;
+			}
 
 			return result;
 		}

--- a/src/ChannelAdvisorAccess/REST/Services/Items/ItemsPagingService.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/Items/ItemsPagingService.cs
@@ -94,7 +94,7 @@ namespace ChannelAdvisorAccess.REST.Services.Items
 				{
 					ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : url ) );
 
-					var resultByPage = await this.GetEntityAsync< ODataResponse< Product > >( nextLink, mark, operationTimeout, token );
+					var resultByPage = await this.GetEntityAsync< ODataResponse< Product > >( nextLink, mark, operationTimeout, token ).ConfigureAwait( false );
 					nextLink = resultByPage.NextLink;
 
 					result.AddRange( resultByPage.Value );

--- a/src/ChannelAdvisorAccess/REST/Services/Items/ItemsPagingService.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/Items/ItemsPagingService.cs
@@ -57,7 +57,7 @@ namespace ChannelAdvisorAccess.REST.Services.Items
 
 			var result = await this.GetProducts( url, mark, token : token ).ConfigureAwait( false );
 
-			return ( from product in result select product.ToInventoryItemResponse() ).ToList();
+			return result.Select( x => x.ToInventoryItemResponse() );
 		}
 
 		/// <summary>
@@ -67,12 +67,12 @@ namespace ChannelAdvisorAccess.REST.Services.Items
 		/// <param name="mark"></param>
 		/// <param name="token"></param>
 		/// <returns></returns>
-		public new async Task< List< string > > GetFilteredSkusAsync( ItemsFilter filter, Mark mark, CancellationToken token = default )
+		public new async Task< IEnumerable< string > > GetFilteredSkusAsync( ItemsFilter filter, Mark mark, CancellationToken token = default )
 		{
 			var url = new ItemsServiceUrlBuilder().GetProductsUrl( filter, "ID,Sku", null );
 			var result = await this.GetProducts( url, mark, this.Timeouts[ ChannelAdvisorOperationEnum.GetProductsByFilterWithIdOnlyRest ], token ).ConfigureAwait( false );
 
-			return result.Select( item => item.Sku ).ToList();
+			return result.Select( item => item.Sku );
 		}
 
 		/// <summary>

--- a/src/ChannelAdvisorAccess/Services/ChannelAdvisorServicesFactory.cs
+++ b/src/ChannelAdvisorAccess/Services/ChannelAdvisorServicesFactory.cs
@@ -120,6 +120,19 @@ namespace ChannelAdvisorAccess.Services
 				return CreateItemsRestService( config.AccountName, config.AccountId, config.AccessToken, config.RefreshToken, timeouts, config.SoapCompatibilityAuth );
 		}
 
+		///  <summary>
+		/// 	Returns Items service
+		///  </summary>
+		///  <param name="config"></param>
+		///  <param name="timeouts"></param>
+		///  <returns></returns>
+		public IItemsService CreateItemsPagingService( ChannelAdvisorConfig config, ChannelAdvisorTimeouts timeouts )
+		{
+			return config.ApiVersion == ChannelAdvisorApiVersion.Soap
+				? this.CreateItemsService( config.AccountName, config.AccountId )
+				: this.CreateItemsPagingRestService( config.AccountName, config.AccountId, config.AccessToken, config.RefreshToken, timeouts, config.SoapCompatibilityAuth );
+		}
+
 		/// <summary>
 		///	Returns Soap items service for concrete tenant
 		/// </summary>
@@ -163,6 +176,40 @@ namespace ChannelAdvisorAccess.Services
 				return this.CreateItemsRestServiceWithSoapCompatibleAuth( accountName, accountId, timeouts );
 			else
 				return new REST.Services.Items.ItemsService( credentials, accountName, accessToken, refreshToken, timeouts );
+		}
+
+		///  <summary>
+		/// 	Returns Rest items service with SOAP compatible authorization flow which return all products in one request
+		///  </summary>
+		///  <param name="accountName"></param>
+		///  <param name="accountId"></param>
+		///  <param name="timeouts"></param>
+		///  <returns></returns>
+		public IItemsService CreateItemsPagingRestServiceWithSoapCompatibleAuth( string accountName, string accountId, ChannelAdvisorTimeouts timeouts )
+		{
+			var credentials = new RestCredentials( this._applicationId, this._sharedSecret );
+			var soapCredentials = new APICredentials { DeveloperKey = this._developerKey, Password = this._developerPassword };
+
+			return new REST.Services.Items.ItemsPagingService( credentials, soapCredentials, accountId, accountName, timeouts );
+		}
+
+		///  <summary>
+		/// 	Returns items Rest service with standard authorization flow which return all products in one request
+		///  </summary>
+		///  <param name="accountName"></param>
+		///  <param name="accountId"></param>
+		///  <param name="accessToken"></param>
+		///  <param name="refreshToken"></param>
+		///  <param name="timeouts"></param>
+		///  <param name="soapCompatibleAuth"></param>
+		///  <returns></returns>
+		public IItemsService CreateItemsPagingRestService( string accountName, string accountId, string accessToken, string refreshToken, ChannelAdvisorTimeouts timeouts, bool soapCompatibleAuth = false )
+		{
+			var credentials = new RestCredentials( this._applicationId, this._sharedSecret );
+
+			return soapCompatibleAuth
+				? this.CreateItemsRestServiceWithSoapCompatibleAuth( accountName, accountId, timeouts )
+				: new REST.Services.Items.ItemsPagingService( credentials, accountName, accessToken, refreshToken, timeouts );
 		}
 
 		public IShippingService CreateShippingService( string accountName, string accountId )

--- a/src/ChannelAdvisorAccessTests/REST/Inventory/ItemsServiceTests.cs
+++ b/src/ChannelAdvisorAccessTests/REST/Inventory/ItemsServiceTests.cs
@@ -353,6 +353,42 @@ namespace ChannelAdvisorAccessTests.REST.Inventory
 			result.Response.Should().NotBeNullOrEmpty();
 			result.AllPagesQueried.Should().BeFalse();
 		}
+		
+		[ Test ]
+		public void GetAllFilteredItemsByUpdateDate()
+		{
+			var filter = new ItemsFilter
+			{
+				Criteria = new InventoryItemCriteria
+				{
+					DateRangeField = TimeStampFields.LastUpdateDate,
+					DateRangeStartGMT = DateTime.Now.AddHours( -24 ),
+					DateRangeEndGMT = DateTime.Now
+				}
+			};
+
+			var result = this.ItemsPagingService.GetFilteredItemsAsync( filter, this.Mark ).GetAwaiter().GetResult();
+
+			result.Should().NotBeNullOrEmpty();
+		}
+		
+		[ Test ]
+		public void GetAllFilteredSkusByUpdateDate()
+		{
+			var filter = new ItemsFilter
+			{
+				Criteria = new InventoryItemCriteria
+				{
+					DateRangeField = TimeStampFields.LastUpdateDate,
+					DateRangeStartGMT = DateTime.Now.AddHours( -24 ),
+					DateRangeEndGMT = DateTime.Now
+				}
+			};
+
+			var result = this.ItemsPagingService.GetFilteredSkusAsync( filter, this.Mark ).GetAwaiter().GetResult();
+
+			result.Should().NotBeNullOrEmpty();
+		}
 
 		[ Test ]
 		public void GetFilteredItemsByUpdateDateAndNotExistingPage()

--- a/src/ChannelAdvisorAccessTests/REST/RestAPITestBase.cs
+++ b/src/ChannelAdvisorAccessTests/REST/RestAPITestBase.cs
@@ -51,11 +51,13 @@ namespace ChannelAdvisorAccessTests.REST
 			if( credentials.useSoapCredentials )
 			{
 				this.ItemsService = ServicesFactory.CreateItemsRestServiceWithSoapCompatibleAuth( credentials.AccountName, credentials.AccountId, timeouts );
+				this.ItemsPagingService = ServicesFactory.CreateItemsPagingRestServiceWithSoapCompatibleAuth( credentials.AccountName, credentials.AccountId, timeouts );
 				this.OrdersService = ServicesFactory.CreateOrdersRestServiceWithSoapCompatibleAuth( credentials.AccountName, credentials.AccountId, this.ItemsService, timeouts );
 			}
 			else
 			{
 				this.ItemsService = ServicesFactory.CreateItemsRestService( credentials.AccountName, null, credentials.AccessToken, credentials.RefreshToken, timeouts );
+				this.ItemsPagingService = ServicesFactory.CreateItemsPagingRestService( credentials.AccountName, null, credentials.AccessToken, credentials.RefreshToken, timeouts );
 				this.OrdersService = ServicesFactory.CreateOrdersRestService( credentials.AccountName, null, credentials.AccessToken, credentials.RefreshToken, timeouts );
 			}
 
@@ -113,6 +115,7 @@ namespace ChannelAdvisorAccessTests.REST
 		public IListingService ListingService{ get; private set; }
 
 		public IItemsService ItemsService{ get; private set; }
+		public IItemsService ItemsPagingService{ get; private set; }
 
 		public IItemsService LightWeightItemsService{ get; private set; }
 


### PR DESCRIPTION
# Description

Tickets: [VT-5739]

Added new implementation for requests in products sync. We will able to get all products/skus in one request to access project. Also fully ignore any condition for build url. We can just take url for next request to CA from previously response. Tested in Access project with client's data.

## Type of change (should only be one)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality change (fix or feature that would cause existing functionality to work differently than before)
- [ ] Configuration change
- [ ] New / updated script
- [ ] Refactoring
- [ ] New tests to existing code

# PR Readiness Checklist

Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it.

- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [X] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings
- [X] Formatted new code, according to the applicable rules

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions

[VT-5739]: https://agileharbor.atlassian.net/browse/VT-5739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ