### PR TITLE
GUARD-2940 Log HTTP response code before throwing network exception

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -76,7 +76,7 @@ task NuGet Package, Version, {
 <package>
 	<metadata>
 		<id>$project_name</id>
-		<version>$Version</version>
+		<version>$Version-alpha</version>
 		<authors>Agile Harbor</authors>
 		<owners>Agile Harbor</owners>
 		<projectUrl>https://github.com/agileharbor/$project_name</projectUrl>

--- a/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
@@ -717,7 +717,10 @@ namespace ChannelAdvisorAccess.REST.Services
 					|| responseStatusCode == _tooManyRequestsStatusCode
 					// batch response sometimes contains this code due to factors on ChannelAdvisor side
 					|| responseStatusCode == (int)HttpStatusCode.NotAcceptable )
-				throw new ChannelAdvisorNetworkException( message );
+				{
+					ChannelAdvisorLogger.LogTrace( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), returnStatusCode: responseStatusCode.ToString(), methodResult: message ));
+					throw new ChannelAdvisorNetworkException( message );
+				}
 			
 			throw new ChannelAdvisorException( responseStatusCode, message );
 		}

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.17.1.5" ) ]
-[ assembly : AssemblyFileVersion( "8.17.1" ) ]
+[ assembly : AssemblyVersion( "8.18.1" ) ]
+[ assembly : AssemblyFileVersion( "8.18.1" ) ]


### PR DESCRIPTION
# Description

Tickets: [GUARD-2940] <!-- Replace with appropriate tickets. Some automation depend on this section, don't remove -->

Pull request goal: Log http response code before throwing a network exception to know the exact code we are getting from ChannelAdvisor.

## Background

To help with troubleshooting, we need to add more logs that can identify the specific type of response that we're receiving from CA endpoints when a network exception is thrown.

## About the changes in this PR

Added new log trace right before we throw a network exception in `RestServiceBaseAbstr`.
![image](https://github.com/skuvault-integrations/channelAdvisorAccess/assets/103965678/6dcd687a-cbbe-4e63-bf02-f08d536af2b5)


## Additional notes

<!--
Mention anything that might be helpful but doesn't belong in the previous section.
-->

<!--
Here are some things you can include in this section (this is just a starting point):

- Mention/link documentation changes resulting from your changes
- Does your code have any known issues that are not being resolved as part of these PR? Why?
-->


# Type of change <!-- should only be one -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality change (fix or feature that would cause existing functionality to work differently than before)
- [ ] Configuration change
- [ ] New / updated script
- [X] Refactoring
- [ ] New tests to existing code

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [X] Followed [development conventions][1] to the best of my ability
- [ ] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-2940]: https://agileharbor.atlassian.net/browse/GUARD-2940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ