### PR TITLE
GUARD-2912 ChannelAdvisor service is not responding fix

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -76,7 +76,7 @@ task NuGet Package, Version, {
 <package>
 	<metadata>
 		<id>$project_name</id>
-		<version>$Version</version>
+		<version>$Version-alpha</version>
 		<authors>Agile Harbor</authors>
 		<owners>Agile Harbor</owners>
 		<projectUrl>https://github.com/agileharbor/$project_name</projectUrl>

--- a/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
@@ -37,7 +37,6 @@ namespace ChannelAdvisorAccess.REST.Services
 		protected string _accessToken;
 		private DateTime _accessTokenExpiredUtc;
 		protected readonly string _refreshToken;
-		private static AutoResetEvent _waitHandle = new AutoResetEvent( true );
 
 		protected string AccountName { get; private set; }
 		protected HttpClient HttpClient { get; private set; }
@@ -160,8 +159,6 @@ namespace ChannelAdvisorAccess.REST.Services
 		/// <returns></returns>
 		private async Task RefreshAccessTokenBySoapCredentials( Mark mark, int? operationTimeout = null, CancellationToken token = default( CancellationToken ) )
 		{
-			_waitHandle.WaitOne();
-
 			this.SetBasicAuthorizationHeader();
 
 			var requestData = new Dictionary< string, string >
@@ -211,7 +208,6 @@ namespace ChannelAdvisorAccess.REST.Services
 			}
 			finally
 			{
-				_waitHandle.Set();
 				this.SetDefaultAuthorizationHeader();
 			}
 		}
@@ -223,7 +219,6 @@ namespace ChannelAdvisorAccess.REST.Services
 		/// <returns></returns>
 		private async Task RefreshAccessTokenByRestCredentials( Mark mark, int? operationTimeout = null, CancellationToken token = default( CancellationToken ) )
 		{
-			_waitHandle.WaitOne();
 			this.SetBasicAuthorizationHeader();
 			AddAccountInfoToHeader();
 
@@ -277,7 +272,6 @@ namespace ChannelAdvisorAccess.REST.Services
 			}
 			finally
 			{
-				_waitHandle.Set();
 				this.SetDefaultAuthorizationHeader();
 			}
 		}

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.18.1" ) ]
-[ assembly : AssemblyFileVersion( "8.18.1" ) ]
+[ assembly : AssemblyVersion( "8.19.1" ) ]
+[ assembly : AssemblyFileVersion( "8.19.1" ) ]


### PR DESCRIPTION
# Description

Tickets: [GUARD-2912] <!-- Replace with appropriate tickets. Some automation depend on this section, don't remove -->

Summary: Prevent the service from hanging indefinitely on `WaitOne()`

## Background

After carefully reviewing the logs, we reached the conclusion that the service gets stuck when calling `WaitOne` in the `RefreshAccessTokenByRestCredentials` method, leading to "service is not responding" errors in v1.

## About these changes

During our discussion with Chris, we agreed that removing all references to `waitHandle (AutoResetEvent)` from the `ServiceBaseAbstr` class would be the best approach since it's the easiest and there are no obvious negative consequences of doing so.

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-2912]: https://agileharbor.atlassian.net/browse/GUARD-2912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ