### PR TITLE
GUARD-3142 Full Inventory 'Can't parse response' error

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -77,7 +77,7 @@ task NuGet Package, Version, {
 <package>
 	<metadata>
 		<id>$project_name</id>
-		<version>$Version</version>
+		<version>$Version-alpha</version>
 		<authors>SkuVault</authors>
 		<owners>SkuVault</owners>
 		<projectUrl>https://github.com/agileharbor/$project_name</projectUrl>

--- a/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
@@ -667,7 +667,7 @@ namespace ChannelAdvisorAccess.REST.Services
 								}
 							}
 
-							await this.ThrowIfError( Math.Max( batchStatusCode, (int)httpResponse.StatusCode  ), content, cts.Token, mark ).ConfigureAwait( false );
+							await this.ThrowIfError( httpResponse.StatusCode == HttpStatusCode.OK ? batchStatusCode : (int)httpResponse.StatusCode, content, cts.Token, mark ).ConfigureAwait( false );
 
 							ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodParameters: url, methodResult: content.ToJson(), additionalInfo : this.AdditionalLogInfo(), operationTimeout: operationTimeout ) );
 						}

--- a/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
@@ -667,7 +667,7 @@ namespace ChannelAdvisorAccess.REST.Services
 								}
 							}
 
-							await this.ThrowIfError( batchStatusCode, content, cts.Token, mark ).ConfigureAwait( false );
+							await this.ThrowIfError( Math.Max( batchStatusCode, (int)httpResponse.StatusCode  ), content, cts.Token, mark ).ConfigureAwait( false );
 
 							ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodParameters: url, methodResult: content.ToJson(), additionalInfo : this.AdditionalLogInfo(), operationTimeout: operationTimeout ) );
 						}

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.22.0" ) ]
-[ assembly : AssemblyFileVersion( "8.22.0" ) ]
+[ assembly : AssemblyVersion( "8.23.0" ) ]
+[ assembly : AssemblyFileVersion( "8.23.0" ) ]


### PR DESCRIPTION
# Description

Tickets: [GUARD-3142] <!-- Replace with appropriate tickets. Some automation depend on this section, don't remove -->

Summary: Fix Full Inventory Sync Error "Can’t parse the response"

## Background

CA sync is not retrying on 429 errors when processing batch requests.

## About these changes

Add the overall `httpResponse.StatusCode` to the `ThrowIfError` call during batch processing. This allows us to retry when the response code is 429, regardless of the `batchStatusCode` value

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [X] I have updated all relevant configuration
- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3142]: https://agileharbor.atlassian.net/browse/GUARD-3142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ