### PR TITLE
VT-6362 ChannelAdvisor: Orders not syncing over to SkuVault

### DIFF
--- a/src/ChannelAdvisorAccess/Properties/AssemblyInfo.cs
+++ b/src/ChannelAdvisorAccess/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -11,3 +12,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [ assembly : Guid( "adc116d4-069d-473a-b2c8-b6b79955ea9e" ) ]
+
+[assembly: InternalsVisibleTo("ChannelAdvisorAccessTests")] 

--- a/src/ChannelAdvisorAccess/REST/Shared/SoapAdapter.cs
+++ b/src/ChannelAdvisorAccess/REST/Shared/SoapAdapter.cs
@@ -119,14 +119,8 @@ namespace ChannelAdvisorAccess.REST.Shared
 					 Title = item.Title,
 					 Quantity = item.Quantity,
 				};
-				
-				var itemFulFillment = order.Fulfillments.FirstOrDefault( f => f.Items.FirstOrDefault( fi => fi.OrderItemID == item.ID ) != null );
 
-				if ( itemFulFillment != null )
-				{
-					var distributionCenter = distributionCenters.FirstOrDefault( dc => dc.ID == itemFulFillment.DistributionCenterID.Value );
-					orderLineItem.DistributionCenterCode = distributionCenter.Code;
-				}
+				orderLineItem.DistributionCenterCode = GetDistributionCenterCode( order.Fulfillments, item.ID, distributionCenters );
 				
 				List< OrderLineItemItemPromo > promotions = new List< OrderLineItemItemPromo >();
 
@@ -183,6 +177,16 @@ namespace ChannelAdvisorAccess.REST.Shared
 			return response;
 		}
 
+		internal static string GetDistributionCenterCode( Fulfillment[] fulfillments, int orderItemId, DistributionCenter[] distributionCenters )
+		{
+			var itemFulFillment = fulfillments.FirstOrDefault( f => f.Items.FirstOrDefault( fi => fi.OrderItemID == orderItemId ) != null );
+
+			if( itemFulFillment?.DistributionCenterID == null )
+				return null;
+
+			return distributionCenters.FirstOrDefault( dc => dc.ID == itemFulFillment.DistributionCenterID.Value )?.Code;
+		}
+		
 		/// <summary>
 		///	Converts REST distribution center to SOAP response
 		/// </summary>

--- a/src/ChannelAdvisorAccessTests/REST/Shared/SoapAdapterTests.cs
+++ b/src/ChannelAdvisorAccessTests/REST/Shared/SoapAdapterTests.cs
@@ -1,4 +1,5 @@
-﻿using ChannelAdvisorAccess.REST.Models;
+﻿using System;
+using ChannelAdvisorAccess.REST.Models;
 using ChannelAdvisorAccess.REST.Shared;
 using FluentAssertions;
 using NUnit.Framework;
@@ -75,6 +76,148 @@ namespace ChannelAdvisorAccessTests.REST.Shared
 
 			// Assert
 			quantityInfoResponse.Available.Should().Be( product.TotalAvailableQuantity );
+		}
+
+		[ Test ]
+		public void GetDistributionCenterCode_ReturnsNull_WhenOrderItemDoesNotExist()
+		{
+			// Arrange
+			var orderItemId = this._randomizer.Next( 0, 100 );
+			var fulfiilments = new[]
+			{
+				new Fulfillment
+				{
+					Items = new[]
+					{
+						new FulfillmentItem
+						{
+							OrderItemID = orderItemId + 1
+						}
+					}
+				}
+			};
+
+			var dcCodes = Array.Empty< DistributionCenter >();
+
+			// Act
+			var dcCode = SoapAdapter.GetDistributionCenterCode( fulfiilments, orderItemId, dcCodes );
+
+			// Assert
+			dcCode.Should().BeNullOrEmpty();
+		}
+
+		[ Test ]
+		public void GetDistributionCenterCode_ReturnsNull_WhenDistributionCenterIdIsNull()
+		{
+			// Arrange
+			var orderItemId = this._randomizer.Next( 0, 100 );
+			var distributionCenterId = this._randomizer.Next( 0, 100 );
+			var distributionCenterCode = Guid.NewGuid().ToString();
+			var fulfiilments = new[]
+			{
+				new Fulfillment
+				{
+					Items = new[]
+					{
+						new FulfillmentItem
+						{
+							OrderItemID = orderItemId
+						}
+					},
+					DistributionCenterID = null
+				}
+			};
+
+			var dcCodes = new[]
+			{
+				new DistributionCenter
+				{
+					ID = distributionCenterId,
+					Code = distributionCenterCode
+				}
+			};
+
+			// Act
+			var dcCode = SoapAdapter.GetDistributionCenterCode( fulfiilments, orderItemId, dcCodes );
+
+			// Assert
+			dcCode.Should().BeNullOrEmpty();
+		}
+
+		[ Test ]
+		public void GetDistributionCenterCode_ReturnsNull_WhenDistributionCenterDoesNotExist()
+		{
+			// Arrange
+			var orderItemId = this._randomizer.Next( 0, 100 );
+			var distributionCenterId = this._randomizer.Next( 0, 100 );
+			var distributionCenterCode = Guid.NewGuid().ToString();
+			var fulfiilments = new[]
+			{
+				new Fulfillment
+				{
+					Items = new[]
+					{
+						new FulfillmentItem
+						{
+							OrderItemID = orderItemId
+						}
+					},
+					DistributionCenterID = distributionCenterId
+				}
+			};
+
+			var dcCodes = new[]
+			{
+				new DistributionCenter
+				{
+					ID = distributionCenterId + 1,
+					Code = distributionCenterCode
+				}
+			};
+
+			// Act
+			var dcCode = SoapAdapter.GetDistributionCenterCode( fulfiilments, orderItemId, dcCodes );
+
+			// Assert
+			dcCode.Should().BeNullOrEmpty();
+		}
+
+		[ Test ]
+		public void GetDistributionCenterCode_ReturnsCode()
+		{
+			// Arrange
+			var orderItemId = this._randomizer.Next( 0, 100 );
+			var distributionCenterId = this._randomizer.Next( 0, 100 );
+			var distributionCenterCode = Guid.NewGuid().ToString();
+			var fulfiilments = new[]
+			{
+				new Fulfillment
+				{
+					Items = new[]
+					{
+						new FulfillmentItem
+						{
+							OrderItemID = orderItemId
+						}
+					},
+					DistributionCenterID = distributionCenterId
+				}
+			};
+
+			var dcCodes = new[]
+			{
+				new DistributionCenter
+				{
+					ID = distributionCenterId,
+					Code = distributionCenterCode
+				}
+			};
+
+			// Act
+			var dcCode = SoapAdapter.GetDistributionCenterCode( fulfiilments, orderItemId, dcCodes );
+
+			// Assert
+			dcCode.Should().Be( distributionCenterCode );
 		}
 	}
 }

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.23.0" ) ]
-[ assembly : AssemblyFileVersion( "8.23.0" ) ]
+[ assembly : AssemblyVersion( "8.24.0" ) ]
+[ assembly : AssemblyFileVersion( "8.24.0" ) ]


### PR DESCRIPTION
# Description

Tickets: [VT-6362]

Summary: We have error https://kibana-prod.skuvault.com/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-15m,to:now))&_a=(columns:!('@timestamp',service.name,service.environment,log.level,message),filters:!(),index:'logs-*',interval:auto,query:(language:kuery,query:'18793'),sort:!(!('@timestamp',desc)))

Object reference not set to an instance of an object.

## Background

I reproduced error on client's data and exactly know reason error.

## About these changes

- Created new method for getting Distribution Code because we don't have any tests here but we have a gigant method.
- Added tests for reproduce error
- Fixed error
- Added new version

# PR Readiness Checklist

- [X] I have updated all relevant configuration
- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [X] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[VT-6362]: https://agileharbor.atlassian.net/browse/VT-6362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ